### PR TITLE
fix: add missing properties to `Transcript` class

### DIFF
--- a/assemblyai/__init__.py
+++ b/assemblyai/__init__.py
@@ -1,33 +1,31 @@
-from .transcriber import Transcriber, Transcript, TranscriptGroup
 from .client import Client
 from .lemur import Lemur
-
+from .transcriber import Transcriber, Transcript, TranscriptGroup
 from .types import (
     AssemblyAIError,
-    Settings,
-    TranscriptError,
-    TranscriptStatus,
-    TranscriptionConfig,
-    Utterance,
-    UtteranceWord,
     LanguageCode,
-    Paragraph,
-    Sentence,
-    LemurModel,
     LemurError,
+    LemurModel,
     LemurQuestion,
     LemurQuestionResult,
-    SummarizationModel,
+    Paragraph,
+    PIIRedactionPolicy,
     PIISubstitutionPolicy,
     RawTranscriptionConfig,
+    Sentence,
+    Settings,
+    SummarizationModel,
     SummarizationType,
+    Timestamp,
+    TranscriptError,
+    TranscriptionConfig,
+    TranscriptStatus,
+    Utterance,
+    UtteranceWord,
+    Word,
     WordBoost,
     WordSearchMatch,
-    Word,
-    Timestamp,
-    PIIRedactionPolicy,
 )
-
 
 settings = Settings()
 """Global settings object that applies to all classes that use the `Client` class."""

--- a/assemblyai/api.py
+++ b/assemblyai/api.py
@@ -1,8 +1,8 @@
-from typing import Optional, List, BinaryIO
-
-from . import types
+from typing import BinaryIO, List, Optional
 
 import httpx
+
+from . import types
 
 
 def _get_error_message(response: httpx.Response) -> str:

--- a/assemblyai/client.py
+++ b/assemblyai/client.py
@@ -1,10 +1,10 @@
 import threading
-from typing import Optional, ClassVar
+from typing import ClassVar, Optional
+
+import httpx
 from typing_extensions import Self
 
 from . import types
-
-import httpx
 
 
 class Client:

--- a/assemblyai/lemur.py
+++ b/assemblyai/lemur.py
@@ -1,7 +1,8 @@
-from typing import Optional, List, Union, Dict, Any
+from typing import Any, Dict, List, Optional, Union
 
-from . import api, types
+from . import api
 from . import client as _client
+from . import types
 
 
 class _LemurImpl:

--- a/assemblyai/transcriber.py
+++ b/assemblyai/transcriber.py
@@ -1,13 +1,16 @@
 from __future__ import annotations
+
+import concurrent.futures
 import os
 import time
+from typing import Dict, Iterator, List, Optional, Union
 from urllib.parse import urlparse
-import concurrent.futures
-from typing import Dict, Iterator, Optional, List, Union
+
 from typing_extensions import Self
 
-from . import lemur, types, api
+from . import api
 from . import client as _client
+from . import lemur, types
 
 
 class _TranscriptImpl:
@@ -212,6 +215,45 @@ class Transcript:
         "The error message in case the transcription fails"
 
         return self._impl.transcript.error
+
+    @property
+    def words(self) -> Optional[List[types.Word]]:
+        "The list of words in the transcript"
+
+        return self._impl.transcript.words
+
+    @property
+    def utterances(self) -> Optional[List[types.Utterance]]:
+        """
+        When `dual_channel` or `speaker_labels` is enabled,
+        a list of utterances in the transcript.
+        """
+
+        return self._impl.transcript.utterances
+
+    @property
+    def confidence(self) -> Optional[float]:
+        "The confidence our model has in the transcribed text, between 0 and 1"
+
+        return self._impl.transcript.confidence
+
+    @property
+    def audio_duration(self) -> Optional[float]:
+        "The duration of the audio in seconds"
+
+        return self._impl.transcript.audio_duration
+
+    @property
+    def webhook_status_code(self) -> Optional[int]:
+        "The status code we received from your server when delivering your webhook"
+
+        return self._impl.transcript.webhook_status_code
+
+    @property
+    def webhook_auth(self) -> Optional[bool]:
+        "Whether the webhook was sent with an HTTP authentication header"
+
+        return self._impl.transcript.webhook_auth
 
     @property
     def lemur(self) -> lemur.Lemur:

--- a/assemblyai/types.py
+++ b/assemblyai/types.py
@@ -1,9 +1,8 @@
 from enum import Enum
-
-from typing import Optional, Dict, Any, List, Tuple, Union, Sequence
-from typing_extensions import Self
+from typing import Any, Dict, List, Optional, Sequence, Tuple, Union
 
 from pydantic import BaseModel, BaseSettings, Extra
+from typing_extensions import Self
 
 
 class AssemblyAIError(Exception):
@@ -1271,7 +1270,7 @@ class BaseTranscript(BaseModel):
     # iab_categories: bool = False
     # "Enable Topic Detection."
 
-    custom_spelling: Optional[List[dict]]
+    custom_spelling: Optional[List[Dict[str, str]]]
     "Customize how words are spelled and formatted using to and from values"
 
     disfluencies: Optional[bool]
@@ -1347,7 +1346,7 @@ class TranscriptResponse(BaseTranscript):
     audio_duration: Optional[float]
     "The duration of your media file, in seconds"
 
-    webhook_status_code: Optional[str]
+    webhook_status_code: Optional[int]
     "The status code we received from your server when delivering your webhook"
     webhook_auth: Optional[bool]
     "Whether the webhook was sent with an HTTP authentication header"

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,13 @@
 from pathlib import Path
 
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 long_description = (Path(__file__).parent / "README.md").read_text()
 
 
 setup(
     name="assemblyai",
-    version="0.4.0",
+    version="0.4.1",
     description="AssemblyAI Python SDK",
     author="AssemblyAI",
     author_email="engineering.sdk@assemblyai.com",

--- a/tests/unit/factories.py
+++ b/tests/unit/factories.py
@@ -4,7 +4,7 @@ from AssemblyAI's API.
 """
 
 from functools import partial
-from typing import Any, Dict, Callable
+from typing import Any, Callable, Dict
 
 import factory
 import factory.base

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,8 +1,8 @@
 import inspect
 
-import assemblyai as aai
-
 import pytest
+
+import assemblyai as aai
 
 
 def test_configuration_are_none_by_default():

--- a/tests/unit/test_lemur.py
+++ b/tests/unit/test_lemur.py
@@ -1,13 +1,11 @@
-import httpx
-from pytest_httpx import HTTPXMock
 import uuid
 
+import httpx
+import pytest
+from pytest_httpx import HTTPXMock
 
 import assemblyai as aai
 from tests.unit import factories
-
-import pytest
-
 
 aai.settings.api_key = "test"
 

--- a/tests/unit/test_transcriber.py
+++ b/tests/unit/test_transcriber.py
@@ -1,11 +1,10 @@
-import httpx
-from pytest_httpx import HTTPXMock
-from unittest.mock import patch, mock_open
-import os
 import copy
+import os
+from unittest.mock import mock_open, patch
 
+import httpx
 import pytest
-
+from pytest_httpx import HTTPXMock
 
 import assemblyai as aai
 from tests.unit import factories

--- a/tests/unit/test_transcript.py
+++ b/tests/unit/test_transcript.py
@@ -1,14 +1,12 @@
 from typing import Any, Dict, List
-import httpx
-from pytest_httpx import HTTPXMock
 
+import httpx
+import pytest
+from faker import Faker
+from pytest_httpx import HTTPXMock
 
 import assemblyai as aai
 from tests.unit import factories
-
-import pytest
-from faker import Faker
-
 
 aai.settings.api_key = "test"
 


### PR DESCRIPTION
## Changes

Adds the following properties to the `Transcript` class:

- `.words`
- `.utterances`
- `.confidence`
- `.audio_duration`
- `.webhook_status_code`
- `.webhook_auth`


