### PR TITLE
ci: add `continue-on-error` to `publish.yml` for `test-pypi`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,6 +34,7 @@ jobs:
       with:
         password: ${{ secrets.TEST_PYPI_API_TOKEN }}
         repository-url: https://test.pypi.org/legacy/
+      continue-on-error: true
     - name: Publish distribution 📦 to PyPI
       if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Minor fix for the CI as the current version `0.5.0` has been created once on Test-PyPi.