### PR TITLE
fix: handle multiple words when using `.word_search(...)`

### DIFF
--- a/assemblyai/api.py
+++ b/assemblyai/api.py
@@ -1,4 +1,5 @@
 from typing import BinaryIO, List, Optional
+from urllib.parse import urlencode
 
 import httpx
 
@@ -142,9 +143,11 @@ def word_search(
 ) -> types.WordSearchMatchResponse:
     response = client.get(
         f"/transcript/{transcript_id}/word-search",
-        params={
-            "words": words,
-        },
+        params=urlencode(
+            {
+                "words": ",".join(words),
+            }
+        ),
     )
 
     if response.status_code != httpx.codes.ok:

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = (Path(__file__).parent / "README.md").read_text()
 
 setup(
     name="assemblyai",
-    version="0.5.0",
+    version="0.5.1",
     description="AssemblyAI Python SDK",
     author="AssemblyAI",
     author_email="engineering.sdk@assemblyai.com",

--- a/tests/unit/test_transcript.py
+++ b/tests/unit/test_transcript.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, List
+from urllib.parse import urlencode
 
 import httpx
 import pytest
@@ -114,9 +115,12 @@ def test_word_search_succeeds(httpx_mock: HTTPXMock):
         factories.WordSearchMatchResponseFactory
     )()
 
+    search_words = {
+        "words": ",".join(["test", "me"]),
+    }
     # mock the specific endpoints
     url = httpx.URL(
-        f"{aai.settings.base_url}/transcript/{transcript.id}/word-search?words=test",
+        f"{aai.settings.base_url}/transcript/{transcript.id}/word-search?{urlencode(search_words)}",
     )
 
     httpx_mock.add_response(
@@ -127,7 +131,7 @@ def test_word_search_succeeds(httpx_mock: HTTPXMock):
     )
 
     # mimic the SDK call
-    matches = transcript.word_search(words=["test"])
+    matches = transcript.word_search(words=["test", "me"])
 
     # check integrity of the response
 


### PR DESCRIPTION
## Changes

Fixes the issue of not finding all the requested words when using multiple words on the `.word_search(..)` method of the `Transcript` class.