### PR TITLE
fix: make polling interval configurable through `Settings`

### DIFF
--- a/assemblyai/transcriber.py
+++ b/assemblyai/transcriber.py
@@ -77,7 +77,7 @@ class _TranscriptImpl:
             ):
                 break
 
-            time.sleep(3)
+            time.sleep(self._client.settings.polling_interval)
 
         return self
 

--- a/assemblyai/types.py
+++ b/assemblyai/types.py
@@ -37,6 +37,9 @@ class Settings(BaseSettings):
     base_url: str = "https://api.assemblyai.com/v2"
     "The base URL for the AssemblyAI API"
 
+    polling_interval: float = 1.0
+    "The default polling interval for long-running requests (e.g. polling the `Transcript`'s status)"
+
     class Config:
         env_prefix = "assemblyai_"
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = (Path(__file__).parent / "README.md").read_text()
 
 setup(
     name="assemblyai",
-    version="0.8.0",
+    version="0.8.1",
     description="AssemblyAI Python SDK",
     author="AssemblyAI",
     author_email="engineering.sdk@assemblyai.com",


### PR DESCRIPTION
## Changes

Allow users to change the polling interval (_used for e.g. polling the `Transcript`'s status_) through the global settings:

Example:

```python
import assemblyai as aai

aai.settings.polling_interval = 0.5
```

or via the environment variable `ASSEMBLYAI_POLLING_INTERVAL`.