### PR TITLE
chore: sync code base with OSS repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ aai.settings.api_key = f"{ASSEMBLYAI_API_KEY}"
 ### **Core Examples**
 
 <details>
-  <summary>Transcribe a local Audio File</summary>
+  <summary>Transcribe a Local Audio File</summary>
 
 ```python
 import assemblyai as aai
@@ -525,8 +525,6 @@ transcriber = aai.RealtimeTranscriber(
   on_close=on_close, # optional
 )
 
-# Start the connection
-transcriber.connect()
 
 # Open a microphone stream
 microphone_stream = aai.extras.MicrophoneStream()
@@ -568,10 +566,9 @@ transcriber = aai.RealtimeTranscriber(
   on_data=on_data,
   on_error=on_error,
   sample_rate=44_100,
+  on_open=on_open, # optional
+  on_close=on_close, # optional
 )
-
-# Start the connection
-transcriber.connect()
 
 
 # Only WAV/PCM16 single channel supported for now

--- a/README.md
+++ b/README.md
@@ -266,6 +266,25 @@ transcriber = aai.Transcriber()
 transcript = transcriber.transcribe("https://example.org/audio.mp3", config)
 ```
 
+To request a copy of the original audio file with the redacted information "beeped" out, set `redact_pii_audio=True` in the config.
+Once the `Transcript` object is returned, you can access the URL of the redacted audio file with `get_redacted_audio_url`, or save the redacted audio directly to disk with `save_redacted_audio`.
+
+```python
+import assemblyai as aai
+
+transcript = aai.Transcriber().transcribe(
+  "https://example.org/audio.mp3",
+  config=aai.TranscriptionConfig(
+    redact_pii=True,
+    redact_pii_policies=[aai.PIIRedactionPolicy.person_name],
+    redact_pii_audio=True
+  )
+)
+
+redacted_audio_url = transcript.get_redacted_audio_url()
+transcript.save_redacted_audio("redacted_audio.mp3")
+```
+
 [Read more about PII redaction here.](https://www.assemblyai.com/docs/Models/pii_redaction)
 
 </details>

--- a/README.md
+++ b/README.md
@@ -544,6 +544,8 @@ transcriber = aai.RealtimeTranscriber(
   on_close=on_close, # optional
 )
 
+# Start the connection
+transcriber.connect()
 
 # Open a microphone stream
 microphone_stream = aai.extras.MicrophoneStream()
@@ -585,10 +587,10 @@ transcriber = aai.RealtimeTranscriber(
   on_data=on_data,
   on_error=on_error,
   sample_rate=44_100,
-  on_open=on_open, # optional
-  on_close=on_close, # optional
 )
 
+# Start the connection
+transcriber.connect()
 
 # Only WAV/PCM16 single channel supported for now
 file_stream = aai.extras.stream_file(

--- a/assemblyai/transcriber.py
+++ b/assemblyai/transcriber.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import base64
 import concurrent.futures
+import functools
 import json
 import os
 import queue
@@ -20,9 +21,9 @@ from typing import (
 )
 from urllib.parse import urlencode, urlparse
 
+import httpx
 import websockets
 import websockets.exceptions
-from httpx import request
 from typing_extensions import Self
 from websockets.sync.client import connect as websocket_connect
 
@@ -149,6 +150,44 @@ class _TranscriptImpl:
         )
 
         return response.paragraphs
+
+    @functools.lru_cache
+    def get_redacted_audio_url(self) -> str:
+        """
+        Retrieve the URL for the PII-redacted audio file, if `redact_pii_audio` was enabled on the `TranscriptionConfig`.
+        Subsequent calls will return cached URL rather than requesting it from the API again.
+
+        Returns: The URL of the redacted audio file.
+        """
+        if not self.config.redact_pii or not self.config.redact_pii_audio:
+            raise ValueError(
+                "Redacted audio is only available when `redact_pii` and `redact_pii_audio` are set to `True`."
+            )
+
+        while True:
+            try:
+                return api.get_redacted_audio(
+                    client=self._client.http_client,
+                    transcript_id=self.transcript_id,
+                ).redacted_audio_url
+            except types.RedactedAudioIncompleteError:
+                time.sleep(self._client.settings.polling_interval)
+
+    def save_redacted_audio(self, filepath: str):
+        """
+        Retrieve the PII-redacted audio file, if `redact_pii_audio` was enabled on the `TranscriptionConfig`
+
+        Args:
+            filepath: The path to save the redacted audio file to.
+        """
+        with httpx.stream(method="GET", url=self.get_redacted_audio_url()) as response:
+            if response.status_code not in (httpx.codes.OK, httpx.codes.NOT_MODIFIED):
+                raise types.RedactedAudioUnavailableError(
+                    f"Fetching redacted audio failed with status code {response.status_code}"
+                )
+            with open(filepath, "wb") as f:
+                for chunk in response.iter_bytes():
+                    f.write(chunk)
 
 
 class Transcript:
@@ -401,6 +440,24 @@ class Transcript:
         """
 
         return self._impl.get_paragraphs()
+
+    def get_redacted_audio_url(self) -> str:
+        """
+        Retrieve the URL for the PII-redacted audio file, if `redact_pii_audio` was enabled on the `TranscriptionConfig`.
+        Subsequent calls will return cached URL rather than requesting it from the API again.
+
+        Returns: The URL of the redacted audio file.
+        """
+        return self._impl.get_redacted_audio_url()
+
+    def save_redacted_audio(self, filepath: str):
+        """
+        Retrieve the PII-redacted audio file, if `redact_pii_audio` was enabled on the `TranscriptionConfig`
+
+        Args:
+            filepath: The path to save the redacted audio file to.
+        """
+        return self._impl.save_redacted_audio(filepath=filepath)
 
 
 class _TranscriptGroupImpl:

--- a/assemblyai/transcriber.py
+++ b/assemblyai/transcriber.py
@@ -1084,13 +1084,20 @@ class _RealtimeTranscriberImpl:
     def _handle_error(self, error: websockets.exceptions.ConnectionClosed) -> None:
         """
         Handles a WebSocket error by calling the appropriate callback.
+
+        See a list of errors here:
+
+        - https://www.iana.org/assignments/websocket/websocket.xhtml#close-code-number
+        - https://www.assemblyai.com/docs/Guides/real-time_streaming_transcription#closing-and-status-codes
         """
         if error.code >= 4000 and error.code <= 4999:
             error_message = types.RealtimeErrorMapping[error.code]
         else:
             error_message = error.reason
 
-        self._on_error(types.RealtimeError(error_message))
+        if error.code != 1000:
+            self._on_error(types.RealtimeError(error_message))
+
         self.close()
 
 

--- a/assemblyai/types.py
+++ b/assemblyai/types.py
@@ -1498,13 +1498,13 @@ class TranscriptResponse(BaseTranscript):
 
     def __init__(self, **data: Any):
         # cleanup the response before creating the object
-        if data.get("iab_categories_result") == {} or (
+        if not data.get("iab_categories_result") or (
             not data.get("iab_categories")
             and data.get("iab_categories_result", {}).get("status") == "unavailable"
         ):
             data["iab_categories_result"] = None
 
-        if data.get("content_safety_labels") == {} or (
+        if not data.get("content_safety_labels") or (
             not data.get("content_safety")
             and data.get("content_safety_labels", {}).get("status") == "unavailable"
         ):

--- a/assemblyai/types.py
+++ b/assemblyai/types.py
@@ -18,6 +18,27 @@ class TranscriptError(AssemblyAIError):
     """
 
 
+class RedactedAudioIncompleteError(AssemblyAIError):
+    """
+    Error class when a PII-redacted audio URL is requested
+    before the file has finished processing
+    """
+
+
+class RedactedAudioExpiredError(AssemblyAIError):
+    """
+    Error class when a PII-redacted audio URL is requested
+    but the file has expired and is no longer available
+    """
+
+
+class RedactedAudioUnavailableError(AssemblyAIError):
+    """
+    Error class when a PII-redacted audio file is requested
+    but it is not available at the given URL
+    """
+
+
 class LemurError(AssemblyAIError):
     """
     Error class when a Lemur request fails
@@ -1280,6 +1301,14 @@ class WordSearchMatchResponse(BaseModel):
 
     matches: List[WordSearchMatch]
     "Contains a list/array of all matched words and associated data"
+
+
+class RedactedAudioResponse(BaseModel):
+    redacted_audio_url: str
+    "The URL of the redacted audio file."
+
+    status: str
+    "Information about the status of the redaction process (will be `redacted_audio_ready` if successful)"
 
 
 class Sentence(Word):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = (Path(__file__).parent / "README.md").read_text()
 
 setup(
     name="assemblyai",
-    version="0.7.1",
+    version="0.11.0",
     description="AssemblyAI Python SDK",
     author="AssemblyAI",
     author_email="engineering.sdk@assemblyai.com",
@@ -15,11 +15,11 @@ setup(
     install_requires=[
         "httpx>=0.19.0",
         "pydantic>=1.7.0",
-        "typing-extensions",
-        "websockets>=10.0",
+        "typing-extensions>=3.7,<4.6",
+        "websockets>=11.0",
     ],
     extras_require={
-        "extras": ["pyaudio"],
+        "extras": ["pyaudio>=0.2.13"],
     },
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = (Path(__file__).parent / "README.md").read_text()
 
 setup(
     name="assemblyai",
-    version="0.10.0",
+    version="0.7.1",
     description="AssemblyAI Python SDK",
     author="AssemblyAI",
     author_email="engineering.sdk@assemblyai.com",
@@ -15,11 +15,11 @@ setup(
     install_requires=[
         "httpx>=0.19.0",
         "pydantic>=1.7.0",
-        "typing-extensions>=3.7,<4.6",
-        "websockets>=11.0",
+        "typing-extensions",
+        "websockets>=10.0",
     ],
     extras_require={
-        "extras": ["pyaudio>=0.2.13"],
+        "extras": ["pyaudio"],
     },
     classifiers=[
         "Development Status :: 3 - Alpha",

--- a/tests/unit/factories.py
+++ b/tests/unit/factories.py
@@ -108,6 +108,19 @@ class TranscriptCompletedResponseFactory(BaseTranscriptFactory):
     webhook_status_code = None
 
 
+class TranscriptQueuedResponseFactory(BaseTranscriptFactory):
+    class Meta:
+        model = types.TranscriptResponse
+
+    id = factory.Faker("uuid4")
+    status = aai.TranscriptStatus.queued
+    text = None
+    words = None
+    utterances = None
+    confidence = None
+    audio_duration = None
+
+
 class TranscriptProcessingResponseFactory(BaseTranscriptFactory):
     class Meta:
         model = types.TranscriptResponse

--- a/tests/unit/test_redact_pii.py
+++ b/tests/unit/test_redact_pii.py
@@ -1,15 +1,25 @@
 import json
 from typing import Any, Dict, Tuple
 
-import factory
 import httpx
 import pytest
 from pytest_httpx import HTTPXMock
+from pytest_mock import MockerFixture
 
 import assemblyai as aai
 from tests.unit import factories
 
 aai.settings.api_key = "test"
+
+
+class TranscriptWithPIIRedactionResponseFactory(
+    factories.TranscriptCompletedResponseFactory
+):
+    redact_pii = True
+    redact_pii_audio = True
+    redact_pii_policies = [
+        aai.types.PIIRedactionPolicy.date,
+    ]
 
 
 def __submit_mock_request(
@@ -68,7 +78,7 @@ def test_redact_pii_disabled_by_default(httpx_mock: HTTPXMock):
     Tests that excluding `redact_pii` from the `TranscriptionConfig` will
     result in the default behavior of it being excluded from the request body
     """
-    request_body, transcript = __submit_mock_request(
+    request_body, _ = __submit_mock_request(
         httpx_mock,
         mock_response=factories.generate_dict_factory(
             factories.TranscriptCompletedResponseFactory
@@ -94,7 +104,7 @@ def test_redact_pii_enabled(httpx_mock: HTTPXMock):
     request_body, _ = __submit_mock_request(
         httpx_mock,
         mock_response=factories.generate_dict_factory(
-            factories.TranscriptCompletedResponseFactory
+            TranscriptWithPIIRedactionResponseFactory
         )(),
         config=aai.TranscriptionConfig(
             redact_pii=True,
@@ -121,7 +131,7 @@ def test_redact_pii_enabled_with_optional_params(httpx_mock: HTTPXMock):
     request_body, _ = __submit_mock_request(
         httpx_mock,
         mock_response=factories.generate_dict_factory(
-            factories.TranscriptCompletedResponseFactory
+            TranscriptWithPIIRedactionResponseFactory
         )(),
         config=aai.TranscriptionConfig(
             redact_pii=True,
@@ -183,3 +193,298 @@ def test_redact_pii_params_excluded_when_disabled(httpx_mock: HTTPXMock):
     assert request_body.get("redact_pii_audio") is None
     assert request_body.get("redact_pii_policies") is None
     assert request_body.get("redact_pii_sub") is None
+
+
+def __get_redacted_audio_api_url(transcript: aai.Transcript) -> str:
+    return f"{aai.settings.base_url}/transcript/{transcript.id}/redacted-audio"
+
+
+REDACTED_AUDIO_URL = "https://example.org/redacted-audio.wav"
+
+
+def __mock_successful_pii_audio_responses(
+    httpx_mock: HTTPXMock, transcript: aai.Transcript
+):
+    # Mock pending redacted audio response on first call
+    httpx_mock.add_response(
+        url=__get_redacted_audio_api_url(transcript),
+        status_code=202,
+        method="GET",
+        json={},
+    )
+
+    # Mock completed redacted audio response on second call
+    httpx_mock.add_response(
+        url=__get_redacted_audio_api_url(transcript),
+        status_code=httpx.codes.OK,
+        method="GET",
+        json={
+            "redacted_audio_url": REDACTED_AUDIO_URL,
+            "status": "redacted_audio_ready",
+        },
+    )
+
+
+def __mock_failed_pii_audio_responses(
+    httpx_mock: HTTPXMock, transcript: aai.Transcript
+):
+    httpx_mock.add_response(
+        url=__get_redacted_audio_api_url(transcript),
+        status_code=400,
+        method="GET",
+        json={},
+    )
+
+
+def test_get_pii_redacted_audio_url(httpx_mock: HTTPXMock):
+    """
+    Tests that the PII-redacted audio URL can be retrieved from the API
+    with a successful response
+    """
+    _, transcript = __submit_mock_request(
+        httpx_mock,
+        mock_response=factories.generate_dict_factory(
+            TranscriptWithPIIRedactionResponseFactory
+        )(),
+        config=aai.TranscriptionConfig(
+            redact_pii=True,
+            redact_pii_policies=[aai.types.PIIRedactionPolicy.date],
+            redact_pii_audio=True,
+        ),
+    )
+
+    __mock_successful_pii_audio_responses(httpx_mock, transcript)
+    redacted_audio_url = transcript.get_redacted_audio_url()
+
+    # Ensure we made a third and fourth network request to get the redacted audio information
+    assert len(httpx_mock.get_requests()) == 4
+
+    assert redacted_audio_url == REDACTED_AUDIO_URL
+
+
+def test_get_pii_redacted_audio_url_fails_if_redact_pii_not_enabled_for_transcript(
+    httpx_mock: HTTPXMock,
+):
+    """
+    Tests that an error is thrown before any requests are made if
+    `redact_pii` was not enabled for the transcript and
+    `get_redacted_audio_url` is called
+    """
+    _, transcript = __submit_mock_request(
+        httpx_mock,
+        mock_response=factories.generate_dict_factory(
+            factories.TranscriptCompletedResponseFactory  # standard response
+        )(),
+        config=aai.TranscriptionConfig(),  # blank config
+    )
+
+    with pytest.raises(ValueError) as error:
+        transcript.get_redacted_audio_url()
+
+    assert "redact_pii" in str(error)
+
+    # Ensure we never made the additional requests to get the redacted audio information
+    assert len(httpx_mock.get_requests()) == 2
+
+
+def test_get_pii_redacted_audio_url_fails_if_redact_pii_audio_not_enabled_for_transcript(
+    httpx_mock: HTTPXMock,
+):
+    """
+    Tests that an error is thrown before any requests are made if
+    `redact_pii_audio` was not enabled for the transcript and
+    `get_redacted_audio_url` is called
+    """
+    _, transcript = __submit_mock_request(
+        httpx_mock,
+        mock_response={
+            **factories.generate_dict_factory(
+                TranscriptWithPIIRedactionResponseFactory
+            )(),
+            "redact_pii_audio": False,
+        },
+        config=aai.TranscriptionConfig(
+            redact_pii=True, redact_pii_policies=[aai.types.PIIRedactionPolicy.date]
+        ),
+    )
+
+    with pytest.raises(ValueError) as error:
+        transcript.get_redacted_audio_url()
+
+    assert "redact_pii_audio" in str(error)
+
+    # Ensure we never made the additional requests to get the redacted audio information
+    assert len(httpx_mock.get_requests()) == 2
+
+
+def test_get_pii_redacted_audio_url_fails_if_bad_response(httpx_mock: HTTPXMock):
+    """
+    Tests that `get_redacted_audio_url` raises a `RedactedAudioUnavailableError` if
+    the request to fetch the redacted audio URL returns a `400` status code, indicating
+    that the redacted audio has expired
+    """
+    _, transcript = __submit_mock_request(
+        httpx_mock,
+        mock_response=factories.generate_dict_factory(
+            TranscriptWithPIIRedactionResponseFactory
+        )(),
+        config=aai.TranscriptionConfig(
+            redact_pii=True,
+            redact_pii_policies=[aai.types.PIIRedactionPolicy.date],
+            redact_pii_audio=True,
+        ),
+    )
+
+    __mock_failed_pii_audio_responses(httpx_mock, transcript)
+    with pytest.raises(aai.types.RedactedAudioExpiredError):
+        transcript.get_redacted_audio_url()
+
+
+def test_save_pii_redacted_audio(httpx_mock: HTTPXMock, mocker: MockerFixture):
+    """
+    Tests that calling `save_redacted_audio` will download the redacted audio file
+    to the caller's file system
+    """
+
+    _, transcript = __submit_mock_request(
+        httpx_mock,
+        mock_response=factories.generate_dict_factory(
+            TranscriptWithPIIRedactionResponseFactory
+        )(),
+        config=aai.TranscriptionConfig(
+            redact_pii=True,
+            redact_pii_policies=[aai.types.PIIRedactionPolicy.date],
+            redact_pii_audio=True,
+        ),
+    )
+
+    # Mock response that returns the redacted-audio URL
+    __mock_successful_pii_audio_responses(httpx_mock, transcript)
+
+    # Mock the redacted-audio URL response
+    mock_audio_file_bytes = b"pretend this is a WAV file"
+    httpx_mock.add_response(
+        url=REDACTED_AUDIO_URL,
+        status_code=httpx.codes.OK,
+        method="GET",
+        content=mock_audio_file_bytes,
+    )
+
+    # Set up mocks for writing to disk
+    mock_file = mocker.mock_open()
+    mocker.patch("builtins.open", mock_file)
+
+    # Download the file
+    downloaded_filepath = "redacted_audio.wav"
+    transcript.save_redacted_audio(downloaded_filepath)
+
+    # Ensure correct filepath was written to
+    mock_file.assert_called_once_with(downloaded_filepath, "wb")
+
+    # Ensure correct file content was written
+    mock_file().write.assert_called_once_with(mock_audio_file_bytes)
+
+
+def test_save_pii_redacted_audio_fails_if_redact_pii_not_enabled_for_transcript(
+    httpx_mock: HTTPXMock,
+):
+    """
+    Tests that an error is thrown before any requests are made if
+    `redact_pii` was not enabled for the transcript and
+    `save_redacted_audio` is called
+    """
+    _, transcript = __submit_mock_request(
+        httpx_mock,
+        mock_response=factories.generate_dict_factory(
+            factories.TranscriptCompletedResponseFactory  # standard response
+        )(),
+        config=aai.TranscriptionConfig(),  # blank config
+    )
+
+    with pytest.raises(ValueError) as error:
+        transcript.save_redacted_audio("redacted_audio.wav")
+
+    assert "redact_pii" in str(error)
+
+    # Ensure we never made the additional requests to get the redacted audio information
+    assert len(httpx_mock.get_requests()) == 2
+
+
+def test_save_pii_redacted_audio_fails_if_redact_pii_audio_not_enabled_for_transcript(
+    httpx_mock: HTTPXMock,
+):
+    """
+    Tests that an error is thrown before any requests are made if
+    `redact_pii_audio` was not enabled for the transcript and
+    `get_redacted_audio_url` is called
+    """
+    _, transcript = __submit_mock_request(
+        httpx_mock,
+        mock_response={
+            **factories.generate_dict_factory(
+                TranscriptWithPIIRedactionResponseFactory
+            )(),
+            "redact_pii_audio": False,
+        },
+        config=aai.TranscriptionConfig(
+            redact_pii=True, redact_pii_policies=[aai.types.PIIRedactionPolicy.date]
+        ),
+    )
+
+    with pytest.raises(ValueError) as error:
+        transcript.save_redacted_audio("redacted_audio.wav")
+
+    assert "redact_pii_audio" in str(error)
+
+    # Ensure we never made the additional requests to get the redacted audio information
+    assert len(httpx_mock.get_requests()) == 2
+
+
+def test_save_pii_redacted_audio_fails_if_bad_response(httpx_mock: HTTPXMock):
+    """
+    Tests that `save_redacted_audio` raises a `RedactedAudioUnavailableError` if
+    the request to fetch the redacted audio URL returns a `400` status code,
+    indicating that the redacted audio has expired
+    """
+    _, transcript = __submit_mock_request(
+        httpx_mock,
+        mock_response=factories.generate_dict_factory(
+            TranscriptWithPIIRedactionResponseFactory
+        )(),
+        config=aai.TranscriptionConfig(
+            redact_pii=True,
+            redact_pii_policies=[aai.types.PIIRedactionPolicy.date],
+            redact_pii_audio=True,
+        ),
+    )
+
+    __mock_failed_pii_audio_responses(httpx_mock, transcript)
+    with pytest.raises(aai.types.RedactedAudioExpiredError):
+        transcript.save_redacted_audio("redacted_audio.wav")
+
+
+def test_save_pii_redacted_audio_fails_if_bad_audio_url_response(httpx_mock: HTTPXMock):
+    """
+    Tests that `save_redacted_audio` raises a `RedactedAudioUnavailableError` if
+    the request to fetch the redacted audio **file** returns a non-200 status code
+    """
+    _, transcript = __submit_mock_request(
+        httpx_mock,
+        mock_response=factories.generate_dict_factory(
+            TranscriptWithPIIRedactionResponseFactory
+        )(),
+        config=aai.TranscriptionConfig(
+            redact_pii=True,
+            redact_pii_policies=[aai.types.PIIRedactionPolicy.date],
+            redact_pii_audio=True,
+        ),
+    )
+
+    __mock_successful_pii_audio_responses(httpx_mock, transcript)
+    httpx_mock.add_response(
+        url=REDACTED_AUDIO_URL,
+        status_code=httpx.codes.NOT_FOUND,
+        method="GET",
+    )
+    with pytest.raises(aai.types.RedactedAudioUnavailableError):
+        transcript.save_redacted_audio("redacted_audio.wav")

--- a/tests/unit/test_transcript_group.py
+++ b/tests/unit/test_transcript_group.py
@@ -1,6 +1,5 @@
 import uuid
 
-import assemblyai.developer_tools.python.sdk as aai
 import assemblyai as aai
 from tests.unit import factories
 

--- a/tests/unit/test_transcript_group.py
+++ b/tests/unit/test_transcript_group.py
@@ -1,0 +1,73 @@
+import uuid
+
+import assemblyai.developer_tools.python.sdk as aai
+import assemblyai as aai
+from tests.unit import factories
+
+
+def test_transcript_group_accepts_transcript_ids():
+    """
+    Tests whether a TranscriptGroup accepts transcript IDs.
+    """
+    transcript_ids = [str(uuid.uuid4()), str(uuid.uuid4())]
+
+    transcript_group = aai.TranscriptGroup(transcript_ids=transcript_ids)
+
+    assert [transcript.id for transcript in transcript_group] == transcript_ids
+
+
+def test_transcript_group_check_status():
+    """
+    Tests the TranscriptGroup's status
+    """
+
+    # create a mock response of a completed transcript
+    mock_completed_transcript = factories.generate_dict_factory(
+        factories.TranscriptCompletedResponseFactory
+    )()
+
+    mock_queued_transcript = factories.generate_dict_factory(
+        factories.TranscriptQueuedResponseFactory
+    )()
+
+    mock_processing_transcript = factories.generate_dict_factory(
+        factories.TranscriptProcessingResponseFactory
+    )()
+
+    mock_error_transcript = factories.generate_dict_factory(
+        factories.TranscriptErrorResponseFactory
+    )()
+
+    transcript_completed = aai.Transcript.from_response(
+        client=aai.Client.get_default(),
+        response=aai.types.TranscriptResponse(**mock_completed_transcript),
+    )
+
+    transcript_queued = aai.Transcript.from_response(
+        client=aai.Client.get_default(),
+        response=aai.types.TranscriptResponse(**mock_queued_transcript),
+    )
+
+    transcript_processing = aai.Transcript.from_response(
+        client=aai.Client.get_default(),
+        response=aai.types.TranscriptResponse(**mock_processing_transcript),
+    )
+
+    transcript_error = aai.Transcript.from_response(
+        client=aai.Client.get_default(),
+        response=aai.types.TranscriptResponse(**mock_error_transcript),
+    )
+
+    transcript_group = aai.TranscriptGroup()
+
+    transcript_group.add_transcript(transcript_completed)
+    assert transcript_group.status == aai.TranscriptStatus.completed
+
+    transcript_group.add_transcript(transcript_queued)
+    assert transcript_group.status == aai.TranscriptStatus.queued
+
+    transcript_group.add_transcript(transcript_processing)
+    assert transcript_group.status == aai.TranscriptStatus.queued
+
+    transcript_group.add_transcript(transcript_error)
+    assert transcript_group.status == aai.TranscriptStatus.error

--- a/tox.ini
+++ b/tox.ini
@@ -16,15 +16,14 @@ deps =
     pydantic1.9: pydantic>=1.9.0,<1.10.0
     pydantic1.8: pydantic>=1.8.0,<1.9.0
     pydantic1.7: pydantic>=1.7.0,<1.8.0
-    typing-extensions: typing-extensions>=3.7,<4.6
+    typing-extensions: typing-extensions>=3.7
     # extra dependencies
-    pyaudiolatest: pyaudio
+    pyaudio: pyaudio
     pyaudio0.2: pyaudio>=0.2.13,<0.3.0
     # test dependencies
     pytest
     pytest-httpx
     pytest-xdist
-    pytest-mock
     pytest-cov
     factory-boy
 allowlist_externals = pytest

--- a/tox.ini
+++ b/tox.ini
@@ -24,6 +24,7 @@ deps =
     pytest
     pytest-httpx
     pytest-xdist
+    pytest-mock
     pytest-cov
     factory-boy
 allowlist_externals = pytest

--- a/tox.ini
+++ b/tox.ini
@@ -16,9 +16,9 @@ deps =
     pydantic1.9: pydantic>=1.9.0,<1.10.0
     pydantic1.8: pydantic>=1.8.0,<1.9.0
     pydantic1.7: pydantic>=1.7.0,<1.8.0
-    typing-extensions: typing-extensions>=3.7
+    typing-extensions: typing-extensions>=3.7,<4.6
     # extra dependencies
-    pyaudio: pyaudio
+    pyaudiolatest: pyaudio
     pyaudio0.2: pyaudio>=0.2.13,<0.3.0
     # test dependencies
     pytest


### PR DESCRIPTION
## Changes

## Features

- Adds PII redacted audio retrieval
- Allows passing `transcript_ids` within the `TranscriptGroup`'s constructor

## Fixes

- Fixes the issue where `on_error` is being called on graceful shutdowns on the `real-time` service.
- Fixes a validation issue on `IAB` and `Content-Safety` that occurred on Transcript's that errored out.