### PR TITLE
fix: add missing `speakers_expected`  to `BaseTranscript`

### DIFF
--- a/assemblyai/types.py
+++ b/assemblyai/types.py
@@ -1421,6 +1421,9 @@ class BaseTranscript(BaseModel):
     speaker_labels: Optional[bool]
     "Enable Speaker Diarization."
 
+    speakers_expected: Optional[int]
+    "The number of speakers you expect to be in your audio file."
+
     content_safety: Optional[bool]
     "Enable Content Safety Detection."
 


### PR DESCRIPTION
## Changes

Adds the `speakers_expected` to the `BaseTranscript` as it was missing there.