### PR TITLE
Feat: Adding `url` and `time` to `EntityType` List

### DIFF
--- a/assemblyai/types.py
+++ b/assemblyai/types.py
@@ -252,6 +252,12 @@ class EntityType(str, Enum):
     banking_information = "banking_information"
     "Banking information, including account and routing numbers"
 
+    time = "time"
+    "Expressions indicating clock times (e.g., 19:37:28, 10pm EST)"
+
+    url = "url"
+    "Internet addresses (e.g., www.assemblyai.com)"
+
 
 # EntityType and PIIRedactionPolicy share the same values
 PIIRedactionPolicy = EntityType


### PR DESCRIPTION
Both `time` and `url` can be returned by our API as entity types, but when they're returned via the SDK right now, we throw an error since we haven't included these two.