### PR TITLE
feat(python/sdk): allow input_text into lemur

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![AssemblyAI Twitter](https://img.shields.io/twitter/follow/AssemblyAI?label=%40AssemblyAI&style=social)](https://twitter.com/AssemblyAI)
 [![AssemblyAI YouTube](https://img.shields.io/youtube/channel/subscribers/UCtatfZMf-8EkIwASXM4ts0A)](https://www.youtube.com/@AssemblyAI)
 [![Discord](https://img.shields.io/discord/875120158014853141?logo=discord&label=Discord&link=https%3A%2F%2Fdiscord.com%2Fchannels%2F875120158014853141&style=social)
-](https://discord.gg/5aQNZyq3)
+](https://assemblyai.com/discord)
 
 # AssemblyAI's Python SDK
 

--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ for sentiment_result in transcript.sentiment_analysis:
   print(sentiment_result.text)
   print(sentiment_result.sentiment)  # POSITIVE, NEUTRAL, or NEGATIVE
   print(sentiment_result.confidence)
-  print(f"Timestamp: {sentiment_result.timestamp.start} - {sentiment_result.timestamp.end}")
+  print(f"Timestamp: {sentiment_result.start} - {sentiment_result.end}")
 ```
 
 If `speaker_labels` is also enabled, then each sentiment analysis result will also include a `speaker` field.

--- a/README.md
+++ b/README.md
@@ -493,7 +493,7 @@ transcript = transcriber.transcribe(
 
 for entity in transcript.entities:
   print(entity.text) # i.e. "Dan Gilbert"
-  print(entity.type) # i.e. EntityType.person
+  print(entity.entity_type) # i.e. EntityType.person
   print(f"Timestamp: {entity.start} - {entity.end}")
 ```
 

--- a/README.md
+++ b/README.md
@@ -266,6 +266,37 @@ print(result.response)
 
 </details>
 
+
+<details>
+  <summary>Use LeMUR to with Input Text</summary>
+
+```python
+import assemblyai as aai
+
+transcriber = aai.Transcriber()
+config = aai.TranscriptionConfig(
+  speaker_labels=True,
+)
+transcript = transcriber.transcribe("https://example.org/customer.mp3", config=config)
+
+# Example converting speaker label utterances into LeMUR input text
+text = ""
+
+for utt in transcript.utterances:
+    text += f"Speaker {utt.speaker}:\n{utt.text}\n"
+
+result = aai.Lemur().task(
+  "You are a helpful coach. Provide an analysis of the transcript "
+  "and offer areas to improve with exact quotes. Include no preamble. "
+  "Start with an overall summary then get into the examples with feedback.",
+  input_text=text
+)
+
+print(result.response)
+```
+
+</details>
+
 <details>
   <summary>Delete data previously sent to LeMUR</summary>
 

--- a/assemblyai/lemur.py
+++ b/assemblyai/lemur.py
@@ -14,7 +14,11 @@ class _LemurImpl:
     ) -> None:
         self._client = client
 
-        self._sources = [types.LemurSourceRequest.from_lemur_source(s) for s in sources]
+        self._sources = (
+            [types.LemurSourceRequest.from_lemur_source(s) for s in sources]
+            if sources is not None
+            else []
+        )
 
     def question(
         self,
@@ -24,6 +28,7 @@ class _LemurImpl:
         final_model: Optional[types.LemurModel],
         max_output_size: Optional[int],
         temperature: Optional[float],
+        input_text: Optional[str],
     ) -> types.LemurQuestionResponse:
         response = api.lemur_question(
             client=self._client.http_client,
@@ -34,6 +39,7 @@ class _LemurImpl:
                 final_model=final_model,
                 max_output_size=max_output_size,
                 temperature=temperature,
+                input_text=input_text,
             ),
             http_timeout=timeout,
         )
@@ -48,6 +54,7 @@ class _LemurImpl:
         max_output_size: Optional[int],
         timeout: Optional[float],
         temperature: Optional[float],
+        input_text: Optional[str],
     ) -> types.LemurSummaryResponse:
         response = api.lemur_summarize(
             client=self._client.http_client,
@@ -58,6 +65,7 @@ class _LemurImpl:
                 final_model=final_model,
                 max_output_size=max_output_size,
                 temperature=temperature,
+                input_text=input_text,
             ),
             http_timeout=timeout,
         )
@@ -72,6 +80,7 @@ class _LemurImpl:
         max_output_size: Optional[int],
         timeout: Optional[float],
         temperature: Optional[float],
+        input_text: Optional[str],
     ) -> types.LemurActionItemsResponse:
         response = api.lemur_action_items(
             client=self._client.http_client,
@@ -82,6 +91,7 @@ class _LemurImpl:
                 final_model=final_model,
                 max_output_size=max_output_size,
                 temperature=temperature,
+                input_text=input_text,
             ),
             http_timeout=timeout,
         )
@@ -95,6 +105,7 @@ class _LemurImpl:
         max_output_size: Optional[int],
         timeout: Optional[float],
         temperature: Optional[float],
+        input_text: Optional[str],
     ):
         response = api.lemur_task(
             client=self._client.http_client,
@@ -104,6 +115,7 @@ class _LemurImpl:
                 final_model=final_model,
                 max_output_size=max_output_size,
                 temperature=temperature,
+                input_text=input_text,
             ),
             http_timeout=timeout,
         )
@@ -121,7 +133,7 @@ class Lemur:
 
     def __init__(
         self,
-        sources: List[types.LemurSource],
+        sources: Optional[List[types.LemurSource]] = None,
         client: Optional[_client.Client] = None,
     ) -> None:
         """
@@ -147,6 +159,7 @@ class Lemur:
         max_output_size: Optional[int] = None,
         timeout: Optional[float] = None,
         temperature: Optional[float] = None,
+        input_text: Optional[str] = None,
     ) -> types.LemurQuestionResponse:
         """
         Question & Answer allows you to ask free form questions about one or many transcripts.
@@ -178,6 +191,7 @@ class Lemur:
             max_output_size=max_output_size,
             timeout=timeout,
             temperature=temperature,
+            input_text=input_text,
         )
 
     def summarize(
@@ -188,6 +202,7 @@ class Lemur:
         max_output_size: Optional[int] = None,
         timeout: Optional[float] = None,
         temperature: Optional[float] = None,
+        input_text: Optional[str] = None,
     ) -> types.LemurSummaryResponse:
         """
         Summary allows you to distill a piece of audio into a few impactful sentences.
@@ -214,6 +229,7 @@ class Lemur:
             max_output_size=max_output_size,
             timeout=timeout,
             temperature=temperature,
+            input_text=input_text,
         )
 
     def action_items(
@@ -224,6 +240,7 @@ class Lemur:
         max_output_size: Optional[int] = None,
         timeout: Optional[float] = None,
         temperature: Optional[float] = None,
+        input_text: Optional[str] = None,
     ) -> types.LemurActionItemsResponse:
         """
         Action Items allows you to generate action items from one or many transcripts.
@@ -251,6 +268,7 @@ class Lemur:
             max_output_size=max_output_size,
             timeout=timeout,
             temperature=temperature,
+            input_text=input_text,
         )
 
     def task(
@@ -260,6 +278,7 @@ class Lemur:
         max_output_size: Optional[int] = None,
         timeout: Optional[float] = None,
         temperature: Optional[float] = None,
+        input_text: Optional[str] = None,
     ) -> types.LemurTaskResponse:
         """
         Task feature allows you to submit a custom prompt to the model.
@@ -282,6 +301,7 @@ class Lemur:
             max_output_size=max_output_size,
             timeout=timeout,
             temperature=temperature,
+            input_text=input_text,
         )
 
     @classmethod

--- a/assemblyai/transcriber.py
+++ b/assemblyai/transcriber.py
@@ -983,7 +983,7 @@ class _RealtimeTranscriberImpl:
         client: _client.Client,
     ) -> None:
         self._client = client
-        self._websocket: Optional[websockets_client.ClientConnection] = None
+        self._websocket: Optional[websockets.sync.client.ClientConnection] = None
 
         self._on_open = on_open
         self._on_data = on_data

--- a/assemblyai/types.py
+++ b/assemblyai/types.py
@@ -1773,6 +1773,7 @@ class BaseLemurRequest(BaseModel):
     final_model: Optional[LemurModel]
     max_output_size: Optional[int]
     temperature: Optional[float]
+    input_text: Optional[str]
 
 
 class LemurTaskRequest(BaseLemurRequest):

--- a/assemblyai/types.py
+++ b/assemblyai/types.py
@@ -835,7 +835,7 @@ class TranscriptionConfig:
         "Enable Auto Chapters."
 
         # Validate required params are also set
-        if enable and self.punctuate == False:
+        if enable and self.punctuate is False:
             raise ValueError(
                 "If `auto_chapters` is enabled, then `punctuate` must not be disabled"
             )
@@ -1146,11 +1146,11 @@ class TranscriptionConfig:
             return self
 
         # Validate that required parameters are also set
-        if self._raw_transcription_config.punctuate == False:
+        if self._raw_transcription_config.punctuate is False:
             raise ValueError(
                 "If `summarization` is enabled, then `punctuate` must not be disabled"
             )
-        if self._raw_transcription_config.format_text == False:
+        if self._raw_transcription_config.format_text is False:
             raise ValueError(
                 "If `summarization` is enabled, then `format_text` must not be disabled"
             )
@@ -1666,7 +1666,7 @@ class LemurTranscriptSource(LemurSource):
         """
         from . import Transcript
 
-        if type(transcript) == str:
+        if isinstance(transcript, str):
             transcript = Transcript(transcript_id=transcript)
 
         super().__init__(transcript)

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = (Path(__file__).parent / "README.md").read_text()
 
 setup(
     name="assemblyai",
-    version="0.19.0",
+    version="0.18.0",
     description="AssemblyAI Python SDK",
     author="AssemblyAI",
     author_email="engineering.sdk@assemblyai.com",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = (Path(__file__).parent / "README.md").read_text()
 
 setup(
     name="assemblyai",
-    version="0.18.0",
+    version="0.20.0",
     description="AssemblyAI Python SDK",
     author="AssemblyAI",
     author_email="engineering.sdk@assemblyai.com",

--- a/tests/unit/test_auto_chapters.py
+++ b/tests/unit/test_auto_chapters.py
@@ -68,7 +68,7 @@ def test_auto_chapters_enabled(httpx_mock: HTTPXMock):
     )
 
     # Check that request body was properly defined
-    assert request_body.get("auto_chapters") == True
+    assert request_body.get("auto_chapters") is True
 
     # Check that transcript was properly parsed from JSON response
     assert transcript.error is None

--- a/tests/unit/test_auto_chapters.py
+++ b/tests/unit/test_auto_chapters.py
@@ -1,13 +1,9 @@
-import json
-from typing import Any, Dict, Tuple
-
 import factory
-import httpx
 import pytest
 from pytest_httpx import HTTPXMock
 
+import tests.unit.unit_test_utils as unit_test_utils
 import assemblyai as aai
-from assemblyai.api import ENDPOINT_TRANSCRIPT
 from tests.unit import factories
 
 aai.settings.api_key = "test"
@@ -17,57 +13,6 @@ class AutoChaptersResponseFactory(factories.TranscriptCompletedResponseFactory):
     chapters = factory.List([factory.SubFactory(factories.ChapterFactory)])
 
 
-def __submit_mock_request(
-    httpx_mock: HTTPXMock,
-    mock_response: Dict[str, Any],
-    config: aai.TranscriptionConfig,
-) -> Tuple[Dict[str, Any], aai.Transcript]:
-    """
-    Helper function to abstract mock transcriber calls with given `TranscriptionConfig`,
-    and perform some common assertions.
-    """
-
-    mock_transcript_id = mock_response.get("id", "mock_id")
-
-    # Mock initial submission response (transcript is processing)
-    mock_processing_response = factories.generate_dict_factory(
-        factories.TranscriptProcessingResponseFactory
-    )()
-
-    httpx_mock.add_response(
-        url=f"{aai.settings.base_url}{ENDPOINT_TRANSCRIPT}",
-        status_code=httpx.codes.OK,
-        method="POST",
-        json={
-            **mock_processing_response,
-            "id": mock_transcript_id,  # inject ID from main mock response
-        },
-    )
-
-    # Mock polling-for-completeness response, with completed transcript
-    httpx_mock.add_response(
-        url=f"{aai.settings.base_url}{ENDPOINT_TRANSCRIPT}/{mock_transcript_id}",
-        status_code=httpx.codes.OK,
-        method="GET",
-        json=mock_response,
-    )
-
-    # == Make API request via SDK ==
-    transcript = aai.Transcriber().transcribe(
-        data="https://example.org/audio.wav",
-        config=config,
-    )
-
-    # Check that submission and polling requests were made
-    assert len(httpx_mock.get_requests()) == 2
-
-    # Extract body of initial submission request
-    request = httpx_mock.get_requests()[0]
-    request_body = json.loads(request.content.decode())
-
-    return request_body, transcript
-
-
 def test_auto_chapters_fails_without_punctuation(httpx_mock: HTTPXMock):
     """
     Tests whether the SDK raises an error before making a request
@@ -75,7 +20,7 @@ def test_auto_chapters_fails_without_punctuation(httpx_mock: HTTPXMock):
     """
 
     with pytest.raises(ValueError) as error:
-        __submit_mock_request(
+        unit_test_utils.submit_mock_transcription_request(
             httpx_mock,
             mock_response={},  # response doesn't matter, since it shouldn't occur
             config=aai.TranscriptionConfig(
@@ -98,7 +43,7 @@ def test_auto_chapters_disabled_by_default(httpx_mock: HTTPXMock):
     Tests that excluding `auto_chapters` from the `TranscriptionConfig` will
     result in the default behavior of it being excluded from the request body
     """
-    request_body, transcript = __submit_mock_request(
+    request_body, transcript = unit_test_utils.submit_mock_transcription_request(
         httpx_mock,
         mock_response=factories.generate_dict_factory(
             factories.TranscriptCompletedResponseFactory
@@ -116,7 +61,7 @@ def test_auto_chapters_enabled(httpx_mock: HTTPXMock):
     response is properly parsed into a `Transcript` object
     """
     mock_response = factories.generate_dict_factory(AutoChaptersResponseFactory)()
-    request_body, transcript = __submit_mock_request(
+    request_body, transcript = unit_test_utils.submit_mock_transcription_request(
         httpx_mock,
         mock_response=mock_response,
         config=aai.TranscriptionConfig(auto_chapters=True),

--- a/tests/unit/test_auto_highlights.py
+++ b/tests/unit/test_auto_highlights.py
@@ -64,7 +64,7 @@ def test_auto_highlights_enabled(httpx_mock: HTTPXMock):
     )
 
     # Check that request body was properly defined
-    assert request_body.get("auto_highlights") == True
+    assert request_body.get("auto_highlights") is True
 
     # Check that transcript was properly parsed from JSON response
     assert transcript.error is None

--- a/tests/unit/test_auto_highlights.py
+++ b/tests/unit/test_auto_highlights.py
@@ -1,12 +1,8 @@
-import json
-from typing import Any, Dict, Tuple
-
 import factory
-import httpx
 from pytest_httpx import HTTPXMock
 
+import tests.unit.unit_test_utils as unit_test_utils
 import assemblyai as aai
-from assemblyai.api import ENDPOINT_TRANSCRIPT
 from tests.unit import factories
 
 aai.settings.api_key = "test"
@@ -36,63 +32,12 @@ class AutohighlightTranscriptResponseFactory(
     auto_highlights_result = factory.SubFactory(AutohighlightResponseFactory)
 
 
-def __submit_mock_request(
-    httpx_mock: HTTPXMock,
-    mock_response: Dict[str, Any],
-    config: aai.TranscriptionConfig,
-) -> Tuple[Dict[str, Any], aai.Transcript]:
-    """
-    Helper function to abstract mock transcriber calls with given `TranscriptionConfig`,
-    and perform some common assertions.
-    """
-
-    mock_transcript_id = mock_response.get("id", "mock_id")
-
-    # Mock initial submission response (transcript is processing)
-    mock_processing_response = factories.generate_dict_factory(
-        factories.TranscriptProcessingResponseFactory
-    )()
-
-    httpx_mock.add_response(
-        url=f"{aai.settings.base_url}{ENDPOINT_TRANSCRIPT}",
-        status_code=httpx.codes.OK,
-        method="POST",
-        json={
-            **mock_processing_response,
-            "id": mock_transcript_id,  # inject ID from main mock response
-        },
-    )
-
-    # Mock polling-for-completeness response, with completed transcript
-    httpx_mock.add_response(
-        url=f"{aai.settings.base_url}{ENDPOINT_TRANSCRIPT}/{mock_transcript_id}",
-        status_code=httpx.codes.OK,
-        method="GET",
-        json=mock_response,
-    )
-
-    # == Make API request via SDK ==
-    transcript = aai.Transcriber().transcribe(
-        data="https://example.org/audio.wav",
-        config=config,
-    )
-
-    # Check that submission and polling requests were made
-    assert len(httpx_mock.get_requests()) == 2
-
-    # Extract body of initial submission request
-    request = httpx_mock.get_requests()[0]
-    request_body = json.loads(request.content.decode())
-
-    return request_body, transcript
-
-
 def test_auto_highlights_disabled_by_default(httpx_mock: HTTPXMock):
     """
     Tests that excluding `auto_highlights` from the `TranscriptionConfig` will
     result in the default behavior of it being excluded from the request body
     """
-    request_body, transcript = __submit_mock_request(
+    request_body, transcript = unit_test_utils.submit_mock_transcription_request(
         httpx_mock,
         mock_response=factories.generate_dict_factory(
             factories.TranscriptCompletedResponseFactory
@@ -112,7 +57,7 @@ def test_auto_highlights_enabled(httpx_mock: HTTPXMock):
     mock_response = factories.generate_dict_factory(
         AutohighlightTranscriptResponseFactory
     )()
-    request_body, transcript = __submit_mock_request(
+    request_body, transcript = unit_test_utils.submit_mock_transcription_request(
         httpx_mock,
         mock_response=mock_response,
         config=aai.TranscriptionConfig(auto_highlights=True),

--- a/tests/unit/test_content_safety.py
+++ b/tests/unit/test_content_safety.py
@@ -98,7 +98,7 @@ def test_content_safety_enabled(httpx_mock: HTTPXMock):
     )
 
     # Check that request body was properly defined
-    assert request_body.get("content_safety") == True
+    assert request_body.get("content_safety") is True
 
     # Check that transcript was properly parsed from JSON response
     assert transcript.error is None
@@ -202,7 +202,7 @@ def test_content_safety_with_confidence_threshold(httpx_mock: HTTPXMock):
         ),
     )
 
-    assert request.get("content_safety") == True
+    assert request.get("content_safety") is True
     assert request.get("content_safety_confidence") == confidence
 
 

--- a/tests/unit/test_content_safety.py
+++ b/tests/unit/test_content_safety.py
@@ -1,14 +1,11 @@
-import json
 import random
-from typing import Any, Dict, Tuple
 
 import factory
-import httpx
 import pytest
 from pytest_httpx import HTTPXMock
 
+import tests.unit.unit_test_utils as unit_test_utils
 import assemblyai as aai
-from assemblyai.api import ENDPOINT_TRANSCRIPT
 from tests.unit import factories
 
 aai.settings.api_key = "test"
@@ -69,63 +66,12 @@ class ContentSafetyTranscriptResponseFactory(
     content_safety_labels = factory.SubFactory(ContentSafetyResponseFactory)
 
 
-def __submit_mock_request(
-    httpx_mock: HTTPXMock,
-    mock_response: Dict[str, Any],
-    config: aai.TranscriptionConfig,
-) -> Tuple[Dict[str, Any], aai.Transcript]:
-    """
-    Helper function to abstract mock transcriber calls with given `TranscriptionConfig`,
-    and perform some common assertions.
-    """
-
-    mock_transcript_id = mock_response.get("id", "mock_id")
-
-    # Mock initial submission response (transcript is processing)
-    mock_processing_response = factories.generate_dict_factory(
-        factories.TranscriptProcessingResponseFactory
-    )()
-
-    httpx_mock.add_response(
-        url=f"{aai.settings.base_url}{ENDPOINT_TRANSCRIPT}",
-        status_code=httpx.codes.OK,
-        method="POST",
-        json={
-            **mock_processing_response,
-            "id": mock_transcript_id,  # inject ID from main mock response
-        },
-    )
-
-    # Mock polling-for-completeness response, with completed transcript
-    httpx_mock.add_response(
-        url=f"{aai.settings.base_url}{ENDPOINT_TRANSCRIPT}/{mock_transcript_id}",
-        status_code=httpx.codes.OK,
-        method="GET",
-        json=mock_response,
-    )
-
-    # == Make API request via SDK ==
-    transcript = aai.Transcriber().transcribe(
-        data="https://example.org/audio.wav",
-        config=config,
-    )
-
-    # Check that submission and polling requests were made
-    assert len(httpx_mock.get_requests()) == 2
-
-    # Extract body of initial submission request
-    request = httpx_mock.get_requests()[0]
-    request_body = json.loads(request.content.decode())
-
-    return request_body, transcript
-
-
 def test_content_safety_disabled_by_default(httpx_mock: HTTPXMock):
     """
     Tests that excluding `content_safety` from the `TranscriptionConfig` will
     result in the default behavior of it being excluded from the request body
     """
-    request_body, transcript = __submit_mock_request(
+    request_body, transcript = unit_test_utils.submit_mock_transcription_request(
         httpx_mock,
         mock_response=factories.generate_dict_factory(
             factories.TranscriptCompletedResponseFactory
@@ -145,7 +91,7 @@ def test_content_safety_enabled(httpx_mock: HTTPXMock):
     mock_response = factories.generate_dict_factory(
         ContentSafetyTranscriptResponseFactory
     )()
-    request_body, transcript = __submit_mock_request(
+    request_body, transcript = unit_test_utils.submit_mock_transcription_request(
         httpx_mock,
         mock_response=mock_response,
         config=aai.TranscriptionConfig(content_safety=True),
@@ -248,7 +194,7 @@ def test_content_safety_with_confidence_threshold(httpx_mock: HTTPXMock):
     and will be included in the request body
     """
     confidence = 40
-    request, _ = __submit_mock_request(
+    request, _ = unit_test_utils.submit_mock_transcription_request(
         httpx_mock,
         mock_response={},  # Response doesn't matter here; we're just testing the request body
         config=aai.TranscriptionConfig(
@@ -269,7 +215,7 @@ def test_content_safety_with_invalid_confidence_threshold(
     an exception to be raised before the request is sent
     """
     with pytest.raises(ValueError) as error:
-        __submit_mock_request(
+        unit_test_utils.submit_mock_transcription_request(
             httpx_mock,
             mock_response={},  # We don't expect to produce a response
             config=aai.TranscriptionConfig(

--- a/tests/unit/test_entity_detection.py
+++ b/tests/unit/test_entity_detection.py
@@ -1,12 +1,8 @@
-import json
-from typing import Any, Dict, Tuple
-
 import factory
-import httpx
 from pytest_httpx import HTTPXMock
 
+import tests.unit.unit_test_utils as unit_test_utils
 import assemblyai as aai
-from assemblyai.api import ENDPOINT_TRANSCRIPT
 from tests.unit import factories
 
 aai.settings.api_key = "test"
@@ -26,63 +22,12 @@ class EntityDetectionResponseFactory(factories.TranscriptCompletedResponseFactor
     entities = factory.List([factory.SubFactory(EntityFactory)])
 
 
-def __submit_mock_request(
-    httpx_mock: HTTPXMock,
-    mock_response: Dict[str, Any],
-    config: aai.TranscriptionConfig,
-) -> Tuple[Dict[str, Any], aai.Transcript]:
-    """
-    Helper function to abstract mock transcriber calls with given `TranscriptionConfig`,
-    and perform some common assertions.
-    """
-
-    mock_transcript_id = mock_response.get("id", "mock_id")
-
-    # Mock initial submission response (transcript is processing)
-    mock_processing_response = factories.generate_dict_factory(
-        factories.TranscriptProcessingResponseFactory
-    )()
-
-    httpx_mock.add_response(
-        url=f"{aai.settings.base_url}{ENDPOINT_TRANSCRIPT}",
-        status_code=httpx.codes.OK,
-        method="POST",
-        json={
-            **mock_processing_response,
-            "id": mock_transcript_id,  # inject ID from main mock response
-        },
-    )
-
-    # Mock polling-for-completeness response, with completed transcript
-    httpx_mock.add_response(
-        url=f"{aai.settings.base_url}{ENDPOINT_TRANSCRIPT}/{mock_transcript_id}",
-        status_code=httpx.codes.OK,
-        method="GET",
-        json=mock_response,
-    )
-
-    # == Make API request via SDK ==
-    transcript = aai.Transcriber().transcribe(
-        data="https://example.org/audio.wav",
-        config=config,
-    )
-
-    # Check that submission and polling requests were made
-    assert len(httpx_mock.get_requests()) == 2
-
-    # Extract body of initial submission request
-    request = httpx_mock.get_requests()[0]
-    request_body = json.loads(request.content.decode())
-
-    return request_body, transcript
-
-
 def test_entity_detection_disabled_by_default(httpx_mock: HTTPXMock):
     """
     Tests that excluding `entity_detection` from the `TranscriptionConfig` will
     result in the default behavior of it being excluded from the request body
     """
-    request_body, transcript = __submit_mock_request(
+    request_body, transcript = unit_test_utils.submit_mock_transcription_request(
         httpx_mock,
         mock_response=factories.generate_dict_factory(
             factories.TranscriptCompletedResponseFactory
@@ -100,7 +45,7 @@ def test_entity_detection_enabled(httpx_mock: HTTPXMock):
     response is properly parsed into a `Transcript` object
     """
     mock_response = factories.generate_dict_factory(EntityDetectionResponseFactory)()
-    request_body, transcript = __submit_mock_request(
+    request_body, transcript = unit_test_utils.submit_mock_transcription_request(
         httpx_mock,
         mock_response=mock_response,
         config=aai.TranscriptionConfig(entity_detection=True),

--- a/tests/unit/test_entity_detection.py
+++ b/tests/unit/test_entity_detection.py
@@ -52,7 +52,7 @@ def test_entity_detection_enabled(httpx_mock: HTTPXMock):
     )
 
     # Check that request body was properly defined
-    assert request_body.get("entity_detection") == True
+    assert request_body.get("entity_detection") is True
 
     # Check that transcript was properly parsed from JSON response
     assert transcript.error is None

--- a/tests/unit/test_iab_categories.py
+++ b/tests/unit/test_iab_categories.py
@@ -1,12 +1,8 @@
-import json
-from typing import Any, Dict, Tuple
-
 import factory
-import httpx
 from pytest_httpx import HTTPXMock
 
+import tests.unit.unit_test_utils as unit_test_utils
 import assemblyai as aai
-from assemblyai.api import ENDPOINT_TRANSCRIPT
 from tests.unit import factories
 
 aai.settings.api_key = "test"
@@ -48,64 +44,13 @@ class IABCategoriesResponseFactory(factories.TranscriptCompletedResponseFactory)
     iab_categories_result = factory.SubFactory(IABResponseFactory)
 
 
-def __submit_mock_request(
-    httpx_mock: HTTPXMock,
-    mock_response: Dict[str, Any],
-    config: aai.TranscriptionConfig,
-) -> Tuple[Dict[str, Any], aai.Transcript]:
-    """
-    Helper function to abstract mock transcriber calls with given `TranscriptionConfig`,
-    and perform some common assertions.
-    """
-
-    mock_transcript_id = mock_response.get("id", "mock_id")
-
-    # Mock initial submission response (transcript is processing)
-    mock_processing_response = factories.generate_dict_factory(
-        factories.TranscriptProcessingResponseFactory
-    )()
-
-    httpx_mock.add_response(
-        url=f"{aai.settings.base_url}{ENDPOINT_TRANSCRIPT}",
-        status_code=httpx.codes.OK,
-        method="POST",
-        json={
-            **mock_processing_response,
-            "id": mock_transcript_id,  # inject ID from main mock response
-        },
-    )
-
-    # Mock polling-for-completeness response, with completed transcript
-    httpx_mock.add_response(
-        url=f"{aai.settings.base_url}{ENDPOINT_TRANSCRIPT}/{mock_transcript_id}",
-        status_code=httpx.codes.OK,
-        method="GET",
-        json=mock_response,
-    )
-
-    # == Make API request via SDK ==
-    transcript = aai.Transcriber().transcribe(
-        data="https://example.org/audio.wav",
-        config=config,
-    )
-
-    # Check that submission and polling requests were made
-    assert len(httpx_mock.get_requests()) == 2
-
-    # Extract body of initial submission request
-    request = httpx_mock.get_requests()[0]
-    request_body = json.loads(request.content.decode())
-
-    return request_body, transcript
-
-
 def test_iab_categories_disabled_by_default(httpx_mock: HTTPXMock):
     """
     Tests that excluding `iab_categories` from the `TranscriptionConfig` will
     result in the default behavior of it being excluded from the request body
     """
 
-    request_body, transcript = __submit_mock_request(
+    request_body, transcript = unit_test_utils.submit_mock_transcription_request(
         httpx_mock,
         mock_response=factories.generate_dict_factory(
             factories.TranscriptCompletedResponseFactory
@@ -125,7 +70,7 @@ def test_iab_categories_enabled(httpx_mock: HTTPXMock):
 
     mock_response = factories.generate_dict_factory(IABCategoriesResponseFactory)()
 
-    request_body, transcript = __submit_mock_request(
+    request_body, transcript = unit_test_utils.submit_mock_transcription_request(
         httpx_mock,
         mock_response=mock_response,
         config=aai.TranscriptionConfig(iab_categories=True),

--- a/tests/unit/test_lemur.py
+++ b/tests/unit/test_lemur.py
@@ -385,7 +385,7 @@ def test_lemur_purge_request_data_fails(httpx_mock: HTTPXMock):
         json=mock_lemur_purge_response,
     )
 
-    with pytest.raises(aai.LemurError) as error:
+    with pytest.raises(aai.LemurError):
         aai.Lemur.purge_request_data(mock_request_id)
 
     assert len(httpx_mock.get_requests()) == 1

--- a/tests/unit/test_lemur.py
+++ b/tests/unit/test_lemur.py
@@ -14,7 +14,7 @@ from tests.unit import factories
 aai.settings.api_key = "test"
 
 
-def test_lemur_single_question_succeeds(httpx_mock: HTTPXMock):
+def test_lemur_single_question_succeeds_transcript(httpx_mock: HTTPXMock):
     """
     Tests whether asking a single question succeeds.
     """
@@ -64,7 +64,54 @@ def test_lemur_single_question_succeeds(httpx_mock: HTTPXMock):
     assert len(httpx_mock.get_requests()) == 1
 
 
-def test_lemur_multiple_question_succeeds(httpx_mock: HTTPXMock):
+def test_lemur_single_question_succeeds_input_text(httpx_mock: HTTPXMock):
+    """
+    Tests whether asking a single question succeeds with input text.
+    """
+
+    # create a mock response of a LemurQuestionResponse
+    mock_lemur_answer = factories.generate_dict_factory(
+        factories.LemurQuestionResponse
+    )()
+
+    # we only want to mock one answer
+    mock_lemur_answer["response"] = [mock_lemur_answer["response"][0]]
+
+    # mock the specific endpoints
+    httpx_mock.add_response(
+        url=f"{aai.settings.base_url}{ENDPOINT_LEMUR}/question-answer",
+        status_code=httpx.codes.OK,
+        method="POST",
+        json=mock_lemur_answer,
+    )
+
+    # prepare the question to be asked
+    question = aai.LemurQuestion(
+        question="Which cars do the callers want to buy?",
+        context="Callers are interested in buying cars",
+        answer_options=["Toyota", "Honda", "Ford", "Chevrolet"],
+    )
+    # test input_text input
+    # mimic the usage of the SDK
+    lemur = aai.Lemur()
+    result = lemur.question(
+        question, input_text="This transcript is a test transcript."
+    )
+
+    # check whether answer is not a list
+    assert isinstance(result, aai.LemurQuestionResponse)
+
+    answers = result.response
+
+    # check the response
+    assert answers[0].question == mock_lemur_answer["response"][0]["question"]
+    assert answers[0].answer == mock_lemur_answer["response"][0]["answer"]
+
+    # check whether we mocked everything
+    assert len(httpx_mock.get_requests()) == 1
+
+
+def test_lemur_multiple_question_succeeds_transcript(httpx_mock: HTTPXMock):
     """
     Tests whether asking multiple questions succeeds.
     """
@@ -117,6 +164,59 @@ def test_lemur_multiple_question_succeeds(httpx_mock: HTTPXMock):
     assert len(httpx_mock.get_requests()) == 1
 
 
+def test_lemur_multiple_question_succeeds_input_text(httpx_mock: HTTPXMock):
+    """
+    Tests whether asking multiple questions succeeds.
+    """
+
+    # create a mock response of a LemurQuestionResponse
+    mock_lemur_answer = factories.generate_dict_factory(
+        factories.LemurQuestionResponse
+    )()
+
+    # prepare the questions to be asked
+    questions = [
+        aai.LemurQuestion(
+            question="Which cars do the callers want to buy?",
+        ),
+        aai.LemurQuestion(
+            question="What price range are the callers looking for?",
+        ),
+    ]
+
+    # update the mock questions with the questions
+    mock_lemur_answer["response"][0]["question"] = questions[0].question
+    mock_lemur_answer["response"][1]["question"] = questions[1].question
+
+    # mock the specific endpoints
+    httpx_mock.add_response(
+        url=f"{aai.settings.base_url}{ENDPOINT_LEMUR}/question-answer",
+        status_code=httpx.codes.OK,
+        method="POST",
+        json=mock_lemur_answer,
+    )
+
+    # test input_text input
+    # mimic the usage of the SDK
+    lemur = aai.Lemur()
+    result = lemur.question(
+        questions, input_text="This transcript is a test transcript."
+    )
+    assert isinstance(result, aai.LemurQuestionResponse)
+
+    answers = result.response
+    # check whether answers is a list
+    assert isinstance(answers, list)
+
+    # check the response
+    for idx, answer in enumerate(answers):
+        assert answer.question == mock_lemur_answer["response"][idx]["question"]
+        assert answer.answer == mock_lemur_answer["response"][idx]["answer"]
+
+    # check whether we mocked everything
+    assert len(httpx_mock.get_requests()) == 1
+
+
 def test_lemur_question_fails(httpx_mock: HTTPXMock):
     """
     Tests whether asking a question fails.
@@ -149,7 +249,7 @@ def test_lemur_question_fails(httpx_mock: HTTPXMock):
     assert len(httpx_mock.get_requests()) == 1
 
 
-def test_lemur_summarize_succeeds(httpx_mock: HTTPXMock):
+def test_lemur_summarize_succeeds_transcript(httpx_mock: HTTPXMock):
     """
     Tests whether summarizing a transcript via LeMUR succeeds.
     """
@@ -172,6 +272,41 @@ def test_lemur_summarize_succeeds(httpx_mock: HTTPXMock):
 
     lemur = aai.Lemur(sources=[aai.LemurSource(transcript)])
     result = lemur.summarize(context="Callers asking for cars", answer_format="TLDR")
+
+    assert isinstance(result, aai.LemurSummaryResponse)
+
+    summary = result.response
+
+    # check the response
+    assert summary == mock_lemur_summary["response"]
+
+    # check whether we mocked everything
+    assert len(httpx_mock.get_requests()) == 1
+
+
+def test_lemur_summarize_succeeds_input_text(httpx_mock: HTTPXMock):
+    """
+    Tests whether summarizing a transcript via LeMUR succeeds with input text.
+    """
+
+    # create a mock response of a LemurSummaryResponse
+    mock_lemur_summary = factories.generate_dict_factory(
+        factories.LemurSummaryResponse
+    )()
+
+    # mock the specific endpoints
+    httpx_mock.add_response(
+        url=f"{aai.settings.base_url}{ENDPOINT_LEMUR}/summary",
+        status_code=httpx.codes.OK,
+        method="POST",
+        json=mock_lemur_summary,
+    )
+
+    # test input_text input
+    lemur = aai.Lemur()
+    result = lemur.summarize(
+        context="Callers asking for cars", answer_format="TLDR", input_text="Test test"
+    )
 
     assert isinstance(result, aai.LemurSummaryResponse)
 
@@ -209,7 +344,7 @@ def test_lemur_summarize_fails(httpx_mock: HTTPXMock):
     assert len(httpx_mock.get_requests()) == 1
 
 
-def test_lemur_action_items_succeeds(httpx_mock: HTTPXMock):
+def test_lemur_action_items_succeeds_transcript(httpx_mock: HTTPXMock):
     """
     Tests whether generating action items for a transcript via LeMUR succeeds.
     """
@@ -234,6 +369,43 @@ def test_lemur_action_items_succeeds(httpx_mock: HTTPXMock):
     result = lemur.action_items(
         context="Customers asking for help with resolving their problem",
         answer_format="Three bullet points",
+    )
+
+    assert isinstance(result, aai.LemurActionItemsResponse)
+
+    action_items = result.response
+
+    # check the response
+    assert action_items == mock_lemur_action_items["response"]
+
+    # check whether we mocked everything
+    assert len(httpx_mock.get_requests()) == 1
+
+
+def test_lemur_action_items_succeeds_input_text(httpx_mock: HTTPXMock):
+    """
+    Tests whether generating action items for a transcript via LeMUR succeeds.
+    """
+
+    # create a mock response of a LemurActionItemsResponse
+    mock_lemur_action_items = factories.generate_dict_factory(
+        factories.LemurActionItemsResponse
+    )()
+
+    # mock the specific endpoints
+    httpx_mock.add_response(
+        url=f"{aai.settings.base_url}{ENDPOINT_LEMUR}/action-items",
+        status_code=httpx.codes.OK,
+        method="POST",
+        json=mock_lemur_action_items,
+    )
+
+    # test input_text input
+    lemur = aai.Lemur()
+    result = lemur.action_items(
+        context="Customers asking for help with resolving their problem",
+        answer_format="Three bullet points",
+        input_text="Test test",
     )
 
     assert isinstance(result, aai.LemurActionItemsResponse)
@@ -275,7 +447,7 @@ def test_lemur_action_items_fails(httpx_mock: HTTPXMock):
     assert len(httpx_mock.get_requests()) == 1
 
 
-def test_lemur_task_succeeds(httpx_mock: HTTPXMock):
+def test_lemur_task_succeeds_transcript(httpx_mock: HTTPXMock):
     """
     Tests whether creating a task request succeeds.
     """
@@ -300,6 +472,38 @@ def test_lemur_task_succeeds(httpx_mock: HTTPXMock):
         sources=[aai.LemurSource(transcript)],
     )
     result = lemur.task(prompt="Create action items of the meeting")
+
+    # check the response
+    assert isinstance(result, aai.LemurTaskResponse)
+
+    assert result.response == mock_lemur_task_response["response"]
+
+    # check whether we mocked everything
+    assert len(httpx_mock.get_requests()) == 1
+
+
+def test_lemur_task_succeeds_input_text(httpx_mock: HTTPXMock):
+    """
+    Tests whether creating a task request succeeds.
+    """
+
+    # create a mock response of a LemurSummaryResponse
+    mock_lemur_task_response = factories.generate_dict_factory(
+        factories.LemurTaskResponse
+    )()
+
+    # mock the specific endpoints
+    httpx_mock.add_response(
+        url=f"{aai.settings.base_url}{ENDPOINT_LEMUR}/task",
+        status_code=httpx.codes.OK,
+        method="POST",
+        json=mock_lemur_task_response,
+    )
+    # test input_text input
+    lemur = aai.Lemur()
+    result = lemur.task(
+        prompt="Create action items of the meeting", input_text="Test test"
+    )
 
     # check the response
     assert isinstance(result, aai.LemurTaskResponse)

--- a/tests/unit/test_realtime_transcriber.py
+++ b/tests/unit/test_realtime_transcriber.py
@@ -1,7 +1,6 @@
 import datetime
 import json
 import uuid
-from typing import Optional
 from unittest.mock import MagicMock
 from urllib.parse import urlencode
 

--- a/tests/unit/test_sentiment_analysis.py
+++ b/tests/unit/test_sentiment_analysis.py
@@ -1,12 +1,8 @@
-import json
-from typing import Any, Dict, Tuple
-
 import factory
-import httpx
 from pytest_httpx import HTTPXMock
 
+import tests.unit.unit_test_utils as unit_test_utils
 import assemblyai as aai
-from assemblyai.api import ENDPOINT_TRANSCRIPT
 from tests.unit import factories
 
 aai.settings.api_key = "test"
@@ -21,63 +17,12 @@ class SentimentAnalysisResponseFactory(factories.TranscriptCompletedResponseFact
     sentiment_analysis_results = factory.List([factory.SubFactory(SentimentFactory)])
 
 
-def __submit_mock_request(
-    httpx_mock: HTTPXMock,
-    mock_response: Dict[str, Any],
-    config: aai.TranscriptionConfig,
-) -> Tuple[Dict[str, Any], aai.Transcript]:
-    """
-    Helper function to abstract mock transcriber calls with given `TranscriptionConfig`,
-    and perform some common assertions.
-    """
-
-    mock_transcript_id = mock_response.get("id", "mock_id")
-
-    # Mock initial submission response (transcript is processing)
-    mock_processing_response = factories.generate_dict_factory(
-        factories.TranscriptProcessingResponseFactory
-    )()
-
-    httpx_mock.add_response(
-        url=f"{aai.settings.base_url}{ENDPOINT_TRANSCRIPT}",
-        status_code=httpx.codes.OK,
-        method="POST",
-        json={
-            **mock_processing_response,
-            "id": mock_transcript_id,  # inject ID from main mock response
-        },
-    )
-
-    # Mock polling-for-completeness response, with completed transcript
-    httpx_mock.add_response(
-        url=f"{aai.settings.base_url}{ENDPOINT_TRANSCRIPT}/{mock_transcript_id}",
-        status_code=httpx.codes.OK,
-        method="GET",
-        json=mock_response,
-    )
-
-    # == Make API request via SDK ==
-    transcript = aai.Transcriber().transcribe(
-        data="https://example.org/audio.wav",
-        config=config,
-    )
-
-    # Check that submission and polling requests were made
-    assert len(httpx_mock.get_requests()) == 2
-
-    # Extract body of initial submission request
-    request = httpx_mock.get_requests()[0]
-    request_body = json.loads(request.content.decode())
-
-    return request_body, transcript
-
-
 def test_sentiment_analysis_disabled_by_default(httpx_mock: HTTPXMock):
     """
     Tests that excluding `sentiment_analysis` from the `TranscriptionConfig` will
     result in the default behavior of it being excluded from the request body
     """
-    request_body, transcript = __submit_mock_request(
+    request_body, transcript = unit_test_utils.submit_mock_transcription_request(
         httpx_mock,
         mock_response=factories.generate_dict_factory(
             factories.TranscriptCompletedResponseFactory
@@ -95,7 +40,7 @@ def test_sentiment_analysis_enabled(httpx_mock: HTTPXMock):
     response is properly parsed into a `Transcript` object
     """
     mock_response = factories.generate_dict_factory(SentimentAnalysisResponseFactory)()
-    request_body, transcript = __submit_mock_request(
+    request_body, transcript = unit_test_utils.submit_mock_transcription_request(
         httpx_mock,
         mock_response=mock_response,
         config=aai.TranscriptionConfig(sentiment_analysis=True),

--- a/tests/unit/test_sentiment_analysis.py
+++ b/tests/unit/test_sentiment_analysis.py
@@ -47,7 +47,7 @@ def test_sentiment_analysis_enabled(httpx_mock: HTTPXMock):
     )
 
     # Check that request body was properly defined
-    assert request_body.get("sentiment_analysis") == True
+    assert request_body.get("sentiment_analysis") is True
 
     # Check that transcript was properly parsed from JSON response
     assert transcript.error is None

--- a/tests/unit/test_summarization.py
+++ b/tests/unit/test_summarization.py
@@ -5,7 +5,6 @@ from pytest_httpx import HTTPXMock
 import tests.unit.factories as factories
 import tests.unit.unit_test_utils as test_utils
 import assemblyai as aai
-from tests.unit import factories
 
 aai.settings.api_key = "test"
 
@@ -74,9 +73,9 @@ def test_default_summarization_params(httpx_mock: HTTPXMock):
     )
 
     # Check that request body was properly defined
-    assert request_body.get("summarization") == True
-    assert request_body.get("summary_model") == None
-    assert request_body.get("summary_type") == None
+    assert request_body.get("summarization") is True
+    assert request_body.get("summary_model") is None
+    assert request_body.get("summary_type") is None
 
     # Check that transcript was properly parsed from JSON response
     assert transcript.error is None
@@ -106,7 +105,7 @@ def test_summarization_with_params(httpx_mock: HTTPXMock):
     )
 
     # Check that request body was properly defined
-    assert request_body.get("summarization") == True
+    assert request_body.get("summarization") is True
     assert request_body.get("summary_model") == summary_model
     assert request_body.get("summary_type") == summary_type
 

--- a/tests/unit/unit_test_utils.py
+++ b/tests/unit/unit_test_utils.py
@@ -1,0 +1,69 @@
+import json
+from typing import Any, Dict, Tuple
+
+import httpx
+from pytest_httpx import HTTPXMock
+
+import assemblyai as aai
+from assemblyai.api import ENDPOINT_TRANSCRIPT
+from tests.unit import factories
+
+
+def submit_mock_transcription_request(
+    httpx_mock: HTTPXMock,
+    mock_response: Dict[str, Any],
+    config: aai.TranscriptionConfig,
+) -> Tuple[Dict[str, Any], aai.transcriber.Transcript]:
+    """
+    Helper function to abstract calling transcriber with given parameters,
+    and perform some common assertions.
+
+    Args:
+        httpx_mock: HTTPXMock instance to use for mocking requests
+        mock_response: Dict to use as mock response from API
+        config: The `TranscriptionConfig` to use for transcription
+
+    Returns:
+        A tuple containing the JSON body of the initial submission request,
+        and the `Transcript` object parsed from the mock response
+    """
+
+    mock_transcript_id = mock_response.get("id", "mock_id")
+
+    # Mock initial submission response (transcript is processing)
+    mock_processing_response = factories.generate_dict_factory(
+        factories.TranscriptProcessingResponseFactory
+    )()
+
+    httpx_mock.add_response(
+        url=f"{aai.settings.base_url}{ENDPOINT_TRANSCRIPT}",
+        status_code=httpx.codes.OK,
+        method="POST",
+        json={
+            **mock_processing_response,
+            "id": mock_transcript_id,  # inject ID from main mock response
+        },
+    )
+
+    # Mock polling-for-completeness response, with completed transcript
+    httpx_mock.add_response(
+        url=f"{aai.settings.base_url}{ENDPOINT_TRANSCRIPT}/{mock_transcript_id}",
+        status_code=httpx.codes.OK,
+        method="GET",
+        json=mock_response,
+    )
+
+    # == Make API request via SDK ==
+    transcript = aai.Transcriber().transcribe(
+        data="https://example.org/audio.wav",
+        config=config,
+    )
+
+    # Check that submission and polling requests were made
+    assert len(httpx_mock.get_requests()) == 2
+
+    # Extract body of initial submission request
+    request = httpx_mock.get_requests()[0]
+    request_body = json.loads(request.content.decode())
+
+    return request_body, transcript


### PR DESCRIPTION
Add the ability to call LeMUR with `input_text`. Update tests. 