### PR TITLE
docs(README): fix typo in lemur example

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ print(result.response)
 
 
 <details>
-  <summary>Use LeMUR to with Input Text</summary>
+  <summary>Use LeMUR with Input Text</summary>
 
 ```python
 import assemblyai as aai


### PR DESCRIPTION
Minor README change to the LeMUR header from "Use LeMUR **to** with Input Text" to "Use LeMUR with Input Text"