### PR TITLE
chore(python/sdk): reduce number of tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39,310,311}-websockets{latest,11.0}-pyaudio{latest,0.2}-httpx{latest,0.24,0.23,0.22,0.21}-pydantic{latest,2,1.10,1.9,1.8,1.7}-typing-extensions
+envlist = py{38,39,310,311}-websockets{latest,11.0}-pyaudio{latest,0.2}-httpx{latest,0.24}-pydantic{latest,2,1.10}-typing-extensions
 
 [testenv]
 deps =
@@ -8,15 +8,15 @@ deps =
     websockets11.0: websockets>=11.0.0,<12.0.0
     httpxlatest: httpx
     httpx0.24: httpx>=0.24.0,<0.25.0
-    httpx0.23: httpx>=0.23.0,<0.24.0
-    httpx0.22: httpx>=0.22.0,<0.23.0
-    httpx0.21: httpx>=0.21.0,<0.22.0
+#    httpx0.23: httpx>=0.23.0,<0.24.0
+#    httpx0.22: httpx>=0.22.0,<0.23.0
+#    httpx0.21: httpx>=0.21.0,<0.22.0
     pydanticlatest: pydantic
     pydantic2: pydantic>=2
     pydantic1.10: pydantic>=1.10.0,<1.11.0,!=1.10.7
-    pydantic1.9: pydantic>=1.9.0,<1.10.0
-    pydantic1.8: pydantic>=1.8.0,<1.9.0
-    pydantic1.7: pydantic>=1.7.0,<1.8.0
+#    pydantic1.9: pydantic>=1.9.0,<1.10.0
+#    pydantic1.8: pydantic>=1.8.0,<1.9.0
+#    pydantic1.7: pydantic>=1.7.0,<1.8.0
     typing-extensions: typing-extensions>=3.7
     # extra dependencies
     pyaudiolatest: pyaudio


### PR DESCRIPTION
No longer test a long list of versions of dependencies to improve CI timelines. 

Problem:
Currently due to the number of tests and versions that need to run the CI pipeline takes ~35 minutes to run. 

Solution:
Reduce the footprint of support to just the latest versions to reduce the amount of time CI takes to run. 