### PR TITLE
Fix `on_error` docstring in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -613,7 +613,7 @@ def on_data(transcript: aai.RealtimeTranscript):
     print(transcript.text, end="\r")
 
 def on_error(error: aai.RealtimeError):
-  "This function is called when the connection has been closed."
+  "This function is called when an error occurs."
 
   print("An error occured:", error)
 


### PR DESCRIPTION
`on_error` docstring identical to `on_close`