### PR TITLE
chore: sync code base with OSS repository

### DIFF
--- a/assemblyai/api.py
+++ b/assemblyai/api.py
@@ -65,6 +65,22 @@ def get_transcript(
     return types.TranscriptResponse.parse_obj(response.json())
 
 
+def delete_transcript(
+    client: httpx.Client,
+    transcript_id: str,
+) -> types.TranscriptResponse:
+    response = client.delete(
+        f"{ENDPOINT_TRANSCRIPT}/{transcript_id}",
+    )
+
+    if response.status_code != httpx.codes.ok:
+        raise types.TranscriptError(
+            f"failed to delete transcript {transcript_id}: {_get_error_message(response)}",
+        )
+
+    return types.TranscriptResponse.parse_obj(response.json())
+
+
 def upload_file(
     client: httpx.Client,
     audio_file: BinaryIO,

--- a/assemblyai/types.py
+++ b/assemblyai/types.py
@@ -368,9 +368,6 @@ class SpeechModel(str, Enum):
     nano = "nano"
     "The Nano tier is a lightweight model that is optimized for speed and cost."
 
-    conformer2 = "conformer-2"
-    "Conformer-2 is a heavy-duty model optimized for accuracy."
-
 
 class RawTranscriptionConfig(BaseModel):
     language_code: Optional[LanguageCode]

--- a/assemblyai/types.py
+++ b/assemblyai/types.py
@@ -1,6 +1,7 @@
 from datetime import datetime
-from enum import Enum
+from enum import Enum, EnumMeta
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple, Union
+from warnings import warn
 
 if TYPE_CHECKING:
     from .transcriber import Transcript
@@ -92,9 +93,46 @@ class TranscriptStatus(str, Enum):
     error = "error"
 
 
-class LanguageCode(str, Enum):
+class DeprecatedLanguageCodeMeta(EnumMeta):
+    def __getattribute__(self, item):
+        # Deprecate all 20 possible values
+        languages = [
+            "de",
+            "en",
+            "en_au",
+            "en_uk",
+            "en_us",
+            "es",
+            "fi",
+            "fr",
+            "hi",
+            "it",
+            "ja",
+            "ko",
+            "nl",
+            "pl",
+            "pt",
+            "ru",
+            "tr",
+            "uk",
+            "vi",
+            "zh",
+        ]
+        if item in languages:
+            warn(
+                "LanuageCode Enum is deprecated and will be removed in 1.0.0. Use a string instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
+        return EnumMeta.__getattribute__(self, item)
+
+
+class LanguageCode(str, Enum, metaclass=DeprecatedLanguageCodeMeta):
     """
-    Supported languages for Transcribing Audio
+    DeprecationWarning: LanuageCode is deprecated and will be removed in 1.0.0. Use a string instead.
+
+    Supported languages for transcribing audio.
     """
 
     de = "de"
@@ -373,11 +411,11 @@ class SpeechModel(str, Enum):
 
 
 class RawTranscriptionConfig(BaseModel):
-    language_code: Optional[LanguageCode]
+    language_code: Optional[Union[str, LanguageCode]]
     """
     The language of your audio file. Possible values are found in Supported Languages.
 
-    The default value is `en_us`.
+    The default value is "en_us".
     """
 
     punctuate: Optional[bool]
@@ -488,7 +526,7 @@ class RawTranscriptionConfig(BaseModel):
 class TranscriptionConfig:
     def __init__(
         self,
-        language_code: Optional[LanguageCode] = None,
+        language_code: Optional[Union[str, LanguageCode]] = None,
         punctuate: Optional[bool] = None,
         format_text: Optional[bool] = None,
         dual_channel: Optional[bool] = None,
@@ -610,12 +648,12 @@ class TranscriptionConfig:
     # region: Getters/Setters
 
     @property
-    def language_code(self) -> Optional[LanguageCode]:
+    def language_code(self) -> Optional[Union[str, LanguageCode]]:
         "The language code of the audio file."
         return self._raw_transcription_config.language_code
 
     @language_code.setter
-    def language_code(self, language_code: Optional[LanguageCode]) -> None:
+    def language_code(self, language_code: Optional[Union[str, LanguageCode]]) -> None:
         "Sets the language code of the audio file."
 
         self._raw_transcription_config.language_code = language_code
@@ -1443,11 +1481,11 @@ class BaseTranscript(BaseModel):
     Available transcription features
     """
 
-    language_code: Optional[LanguageCode]
+    language_code: Optional[Union[str, LanguageCode]]
     """
     The language of your audio file. Possible values are found in Supported Languages.
 
-    The default value is `en_us`.
+    The default value is "en_us".
     """
 
     audio_url: str

--- a/assemblyai/types.py
+++ b/assemblyai/types.py
@@ -368,6 +368,9 @@ class SpeechModel(str, Enum):
     nano = "nano"
     "The Nano tier is a lightweight model that is optimized for speed and cost."
 
+    conformer2 = "conformer-2"
+    "Conformer-2 is a heavy-duty model optimized for accuracy."
+
 
 class RawTranscriptionConfig(BaseModel):
     language_code: Optional[LanguageCode]

--- a/assemblyai/types.py
+++ b/assemblyai/types.py
@@ -403,8 +403,11 @@ class SpeechModel(str, Enum):
     Used for AssemblyAI's Speech Model feature.
     """
 
+    best = "best"
+    "The best model optimized for accuracy."
+
     nano = "nano"
-    "The Nano tier is a lightweight model that is optimized for speed and cost."
+    "A lightweight, lower cost model for a wide range of languages."
 
     conformer2 = "conformer-2"
     "Conformer-2 is a heavy-duty model optimized for accuracy."

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = (Path(__file__).parent / "README.md").read_text()
 
 setup(
     name="assemblyai",
-    version="0.23.0",
+    version="0.23.1",
     description="AssemblyAI Python SDK",
     author="AssemblyAI",
     author_email="engineering.sdk@assemblyai.com",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = (Path(__file__).parent / "README.md").read_text()
 
 setup(
     name="assemblyai",
-    version="0.23.1",
+    version="0.23.0",
     description="AssemblyAI Python SDK",
     author="AssemblyAI",
     author_email="engineering.sdk@assemblyai.com",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = (Path(__file__).parent / "README.md").read_text()
 
 setup(
     name="assemblyai",
-    version="0.23.1",
+    version="0.24.0",
     description="AssemblyAI Python SDK",
     author="AssemblyAI",
     author_email="engineering.sdk@assemblyai.com",

--- a/tests/unit/factories.py
+++ b/tests/unit/factories.py
@@ -61,7 +61,7 @@ class BaseTranscriptFactory(factory.Factory):
     class Meta:
         model = types.BaseTranscript
 
-    language_code = aai.LanguageCode.en
+    language_code = "en"
     audio_url = factory.Faker("url")
     punctuate = True
     format_text = True

--- a/tests/unit/factories.py
+++ b/tests/unit/factories.py
@@ -113,6 +113,10 @@ class TranscriptCompletedResponseFactory(BaseTranscriptResponseFactory):
     pass
 
 
+class TranscriptCompletedResponseFactoryBest(BaseTranscriptResponseFactory):
+    speech_model = "best"
+
+
 class TranscriptCompletedResponseFactoryNano(BaseTranscriptResponseFactory):
     speech_model = "nano"
 

--- a/tests/unit/factories.py
+++ b/tests/unit/factories.py
@@ -109,6 +109,50 @@ class BaseTranscriptResponseFactory(BaseTranscriptFactory):
     webhook_status_code = None
 
 
+class TranscriptDeletedResponseFactory(BaseTranscriptResponseFactory):
+    language_code = None
+    audio_url = "http://deleted_by_user"
+    text = "Deleted by user."
+    words = None
+    utterances = None
+    confidence = None
+    punctuate = None
+    format_text = None
+    dual_channel = None
+    webhook_url = "http://deleted_by_user"
+    webhook_status_code = None
+    webhook_auth = False
+    # webhook_auth_header_name = None  # not yet supported in SDK
+    speed_boost = None
+    auto_highlights = None
+    audio_start_from = None
+    audio_end_at = None
+    word_boost = None
+    boost_param = None
+    filter_profanity = None
+    redact_pii_audio = None
+    # redact_pii_quality = None # not yet supported in SDK
+    redact_pii_policies = None
+    redact_pii_sub = None
+    speaker_labels = None
+    error = None
+    content_safety = None
+    iab_categories = None
+    content_safety_labels = None
+    iab_categories = None
+    language_detection = None
+    custom_spelling = None
+    # cluster_id = None  # not yet supported in SDK
+    # custom_topics = None  # not yet supported in SDK
+    # topics = None  # not yet supported in SDK
+    speech_threshold = None
+    chapters = None
+    entities = None
+    speakers_expected = None
+    summary = None
+    sentiment_analysis = None
+
+
 class TranscriptCompletedResponseFactory(BaseTranscriptResponseFactory):
     pass
 

--- a/tests/unit/test_transcriber.py
+++ b/tests/unit/test_transcriber.py
@@ -451,3 +451,44 @@ def test_language_detection(httpx_mock: HTTPXMock):
     request = json.loads(httpx_mock.get_requests()[0].content.decode())
     assert request["language_detection"] is True
     assert request.get("language_code") is None
+
+
+def test_language_code_string(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        url=f"{aai.settings.base_url}{ENDPOINT_TRANSCRIPT}",
+        status_code=httpx.codes.OK,
+        method="POST",
+        json={},
+    )
+
+    aai.Transcriber().transcribe(
+        "https://example.org/audio.wav",
+        config=aai.TranscriptionConfig(
+            language_code="en",
+        ),
+    )
+
+    request = json.loads(httpx_mock.get_requests()[0].content.decode())
+    assert request.get("language_code") == "en"
+
+
+def test_language_code_enum(httpx_mock: HTTPXMock):
+    httpx_mock.add_response(
+        url=f"{aai.settings.base_url}{ENDPOINT_TRANSCRIPT}",
+        status_code=httpx.codes.OK,
+        method="POST",
+        json={},
+    )
+
+    with pytest.deprecated_call():
+        language_code = aai.LanguageCode.en
+
+    aai.Transcriber().transcribe(
+        "https://example.org/audio.wav",
+        config=aai.TranscriptionConfig(
+            language_code=language_code,
+        ),
+    )
+
+    request = json.loads(httpx_mock.get_requests()[0].content.decode())
+    assert request.get("language_code") == "en"

--- a/tests/unit/test_transcript.py
+++ b/tests/unit/test_transcript.py
@@ -376,3 +376,49 @@ def test_get_by_id_async(httpx_mock: HTTPXMock, speech_model):
     assert transcript.id == transcript_id
     assert transcript.error is None
     assert transcript.speech_model == speech_model
+
+
+def test_delete_by_id(httpx_mock: HTTPXMock):
+    mock_transcript_response = factories.generate_dict_factory(
+        factories.TranscriptDeletedResponseFactory
+    )()
+    transcript_id = mock_transcript_response["id"]
+    httpx_mock.add_response(
+        url=f"{aai.settings.base_url}{ENDPOINT_TRANSCRIPT}/{transcript_id}",
+        status_code=httpx.codes.OK,
+        method="DELETE",
+        json=mock_transcript_response,
+    )
+
+    transcript = aai.Transcript.delete_by_id(transcript_id)
+
+    assert isinstance(transcript, aai.Transcript)
+    assert transcript.status == aai.TranscriptStatus.completed
+    assert transcript.id == transcript_id
+    assert transcript.error is None
+    assert transcript.text == mock_transcript_response["text"]
+    assert transcript.audio_url == mock_transcript_response["audio_url"]
+
+
+def test_delete_by_id_async(httpx_mock: HTTPXMock):
+    mock_transcript_response = factories.generate_dict_factory(
+        factories.TranscriptDeletedResponseFactory
+    )()
+    transcript_id = mock_transcript_response["id"]
+
+    httpx_mock.add_response(
+        url=f"{aai.settings.base_url}{ENDPOINT_TRANSCRIPT}/{transcript_id}",
+        status_code=httpx.codes.OK,
+        method="DELETE",
+        json=mock_transcript_response,
+    )
+
+    transcript_future = aai.Transcript.delete_by_id_async(transcript_id)
+    transcript = transcript_future.result()
+
+    assert isinstance(transcript, aai.Transcript)
+    assert transcript.status == aai.TranscriptStatus.completed
+    assert transcript.id == transcript_id
+    assert transcript.error is None
+    assert transcript.text == mock_transcript_response["text"]
+    assert transcript.audio_url == mock_transcript_response["audio_url"]

--- a/tests/unit/test_transcript.py
+++ b/tests/unit/test_transcript.py
@@ -308,14 +308,25 @@ def test_get_sentences_and_paragraphs_fails(httpx_mock: HTTPXMock):
     assert len(httpx_mock.get_requests()) == 2
 
 
-@pytest.mark.parametrize("speech_model", [None, SpeechModel.nano])
+@pytest.mark.parametrize(
+    "speech_model",
+    [
+        None,
+        SpeechModel.best,
+        SpeechModel.nano,
+    ],
+)
 def test_get_by_id(httpx_mock: HTTPXMock, speech_model):
     transcript_id = "123"
-    mock_transcript_response = factories.generate_dict_factory(
-        factories.TranscriptCompletedResponseFactory
-        if speech_model is None
-        else factories.TranscriptCompletedResponseFactoryNano
-    )()
+
+    factory_class = factories.TranscriptCompletedResponseFactory
+    if speech_model == SpeechModel.best:
+        factory_class = factories.TranscriptCompletedResponseFactoryBest
+    elif speech_model == SpeechModel.nano:
+        factory_class = factories.TranscriptCompletedResponseFactoryNano
+
+    mock_transcript_response = factories.generate_dict_factory(factory_class)()
+
     httpx_mock.add_response(
         url=f"{aai.settings.base_url}{ENDPOINT_TRANSCRIPT}/{transcript_id}",
         status_code=httpx.codes.OK,
@@ -332,14 +343,23 @@ def test_get_by_id(httpx_mock: HTTPXMock, speech_model):
     assert transcript.speech_model == speech_model
 
 
-@pytest.mark.parametrize("speech_model", [None, SpeechModel.nano])
+@pytest.mark.parametrize(
+    "speech_model",
+    [
+        None,
+        SpeechModel.best,
+        SpeechModel.nano,
+    ],
+)
 def test_get_by_id_async(httpx_mock: HTTPXMock, speech_model):
     transcript_id = "123"
-    mock_transcript_response = factories.generate_dict_factory(
-        factories.TranscriptCompletedResponseFactory
-        if speech_model is None
-        else factories.TranscriptCompletedResponseFactoryNano
-    )()
+    factory_class = factories.TranscriptCompletedResponseFactory
+    if speech_model == SpeechModel.best:
+        factory_class = factories.TranscriptCompletedResponseFactoryBest
+    elif speech_model == SpeechModel.nano:
+        factory_class = factories.TranscriptCompletedResponseFactoryNano
+
+    mock_transcript_response = factories.generate_dict_factory(factory_class)()
 
     httpx_mock.add_response(
         url=f"{aai.settings.base_url}{ENDPOINT_TRANSCRIPT}/{transcript_id}",


### PR DESCRIPTION
## Changes

### Features
- Add `SpeechModel.best`
- Add string support for `language_code` parameter
- Add support to delete transcripts (#56):
    - `Transcript.delete_by_id()` and `Transcript.delete_by_id_async` 

### Deprecation
- Deprecate `LanguageCode` enum. It will be removed in 1.0.0. Use strings instead.

