### PR TITLE
chore: sync code base with OSS repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,11 @@ import assemblyai as aai
 
 transcriber = aai.Transcriber()
 
-# Upload binary data.
-upload_url = transcriber.upload_file(data)
+# Binary data is supported directly:
+transcript = transcriber.transcribe(data)
 
+# Or: Upload data separately:
+upload_url = transcriber.upload_file(data)
 transcript = transcriber.transcribe(upload_url)
 ```
 

--- a/README.md
+++ b/README.md
@@ -98,15 +98,16 @@ print(transcript.text)
 </details>
 
 <details>
-  <summary>Transcribe from stream</summary>
+  <summary>Transcribe binary data</summary>
 
 ```python
 import assemblyai as aai
 
-# Upload binary data.
-upload_url = aai.extras.file_from_stream(data)
-
 transcriber = aai.Transcriber()
+
+# Upload binary data.
+upload_url = transcriber.upload_file(data)
+
 transcript = transcriber.transcribe(upload_url)
 ```
 

--- a/assemblyai/extras.py
+++ b/assemblyai/extras.py
@@ -1,5 +1,6 @@
 import time
 from typing import BinaryIO, Generator
+from warnings import warn
 
 from . import api
 from .client import Client
@@ -116,6 +117,8 @@ def stream_file(
 
 def file_from_stream(data: BinaryIO) -> str:
     """
+    DeprecationWarning: `file_from_stream()` is deprecated and will be removed in 1.0.0. Use `Transcriber.upload_file()` instead.
+
     Uploads the given stream and returns the uploaded audio url.
 
     This function can be used to transcribe data that's already
@@ -132,6 +135,11 @@ def file_from_stream(data: BinaryIO) -> str:
     Args:
         `data`: A file-like object (in binary mode)
     """
+    warn(
+        "`file_from_stream()` is deprecated and will be removed in 1.0.0. Use `Transcriber.upload_file()` instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return api.upload_file(
         client=Client.get_default().http_client,
         audio_file=data,

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ long_description = (Path(__file__).parent / "README.md").read_text()
 
 setup(
     name="assemblyai",
-    version="0.25.0",
+    version="0.26.0",
     description="AssemblyAI Python SDK",
     author="AssemblyAI",
     author_email="engineering.sdk@assemblyai.com",


### PR DESCRIPTION
# Changes

## Features
- Add `Transcriber.upload()` and `Transcriber.upload_async()` (#59)
- Add support for `BinaryIO` type for `submit()` and `transcribe()` (#58)

## Deprecation
- Deprecate `extras.file_from_stream`. The new `upload()` functions can be used instead.


