### PR TITLE
feat: add webhook support to streaming parameters

### DIFF
--- a/assemblyai/streaming/v3/models.py
+++ b/assemblyai/streaming/v3/models.py
@@ -89,6 +89,9 @@ class StreamingParameters(StreamingSessionParameters):
     speech_model: Optional[SpeechModel] = None
     language_detection: Optional[bool] = None
     inactivity_timeout: Optional[int] = None
+    webhook_url: Optional[str] = None
+    webhook_auth_header_name: Optional[str] = None
+    webhook_auth_header_value: Optional[str] = None
 
 
 class UpdateConfiguration(StreamingSessionParameters):


### PR DESCRIPTION
## Summary
- Add `webhook_url`, `webhook_auth_header_name`, and `webhook_auth_header_value` fields to `StreamingParameters`
- These are passed as query params on the WebSocket URL, enabling server-side webhook delivery of the transcript when a streaming session ends
- Docs: https://assemblyai-preview-6804fd2c-e8bf-4886-8dbc-b94c49176ae1.docs.buildwithfern.com/docs/deployment/webhooks-for-streaming-speech-to-text

## Changes
- `assemblyai/streaming/v3/models.py` — 3 new optional fields on `StreamingParameters`
- `tests/unit/test_streaming.py` — new `test_client_connect_with_webhook` test

## Test plan
- [x] Unit test verifies webhook params appear in the WebSocket URL query string
- [x] All 5 streaming tests pass