### PR TITLE
Add warning callout: SDK is for testing/light usage only

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@
 
 With a single API call, get access to AI models built on the latest AI breakthroughs to transcribe and understand audio and speech data securely at large scale.
 
+> **⚠️ WARNING**
+> This SDK is intended for **testing and light usage only**. It is not recommended for use at scale or with production traffic. For best results, we recommend calling the AssemblyAI API directly via HTTP request. See our [official documentation](https://www.assemblyai.com/docs) for more information, including HTTP code examples.
+
 # Overview
 
 - [AssemblyAI's Python SDK](#assemblyais-python-sdk)


### PR DESCRIPTION
Adds a prominent warning callout to the README advising that this SDK is intended for testing and light usage only, and recommending direct HTTP API calls for production traffic at scale. Links to official docs for HTTP code examples.