### PR TITLE
docs: add PocketStation dual-channel streaming example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1141,7 +1141,25 @@ Back-filled words are flagged `word.channel_resolved = True`; confident per-word
 - Capturing the system/speaker output is platform-specific: macOS needs a loopback driver (e.g. BlackHole); Windows uses WASAPI loopback; Linux a PulseAudio/PipeWire monitor source.
 - If the mic physically picks up the speakers, that bleed can pull attribution toward `mic`. Apply acoustic echo cancellation at capture (`getUserMedia({ audio: { echoCancellation: true } })` in browser front-ends, or an AEC-capable native path) — the SDK only receives already-captured PCM, so it can't apply AEC itself. Transcription quality is unaffected; only the `channel` field.
 
-See [`examples/streaming_dual_channel.py`](./examples/streaming_dual_channel.py) for a complete runnable demo.
+The runnable example uses PocketStation to capture one desktop application and,
+when requested, the default microphone as separate sources. PocketStation does
+not require a virtual audio device for application capture.
+
+```bash
+python -m pip install assemblyai==1.3.0 pocketstation==0.1.3
+export ASSEMBLYAI_API_KEY=your_api_key
+python examples/streaming_dual_channel.py
+```
+
+The example asks which running application to transcribe. Add the microphone
+explicitly when you need both sides of a conversation:
+
+```bash
+python examples/streaming_dual_channel.py --application Zoom --microphone
+```
+
+See [`examples/streaming_dual_channel.py`](./examples/streaming_dual_channel.py)
+for the complete program.
 
 </details>
 

--- a/examples/streaming_dual_channel.py
+++ b/examples/streaming_dual_channel.py
@@ -1,0 +1,183 @@
+"""Transcribe one desktop application and an optional microphone live."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+from array import array
+from collections.abc import Sequence
+
+SAMPLE_RATE_HZ = 16_000
+
+
+def pcm_s16le(samples: memoryview) -> bytes:
+    """Convert normalized float samples to little-endian signed 16-bit PCM."""
+    converted = array("h")
+    converted.extend(
+        -32_768 if sample <= -1.0 else 32_767 if sample >= 1.0 else int(sample * 32_767)
+        for sample in samples
+    )
+    if sys.byteorder != "little":
+        converted.byteswap()
+    return converted.tobytes()
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Transcribe a running desktop application with AssemblyAI. "
+            "Add --microphone to keep local speech on a separate channel."
+        )
+    )
+    parser.add_argument(
+        "--application",
+        help="exact display name or application identifier to capture",
+    )
+    parser.add_argument(
+        "--microphone",
+        action="store_true",
+        help="also capture the default microphone",
+    )
+    parser.add_argument(
+        "--duration",
+        type=float,
+        help="stop automatically after this many seconds",
+    )
+    args = parser.parse_args(argv)
+    if args.duration is not None and args.duration <= 0:
+        parser.error("--duration must be greater than zero")
+    return args
+
+
+async def run(args: argparse.Namespace) -> None:
+    import pocketstation as pks
+    import pocketstation.aio as pks_aio
+    from pocketstation.observations import SessionEventType
+
+    from assemblyai.streaming.v3 import (
+        AsyncChannelStreamer,
+        AsyncRealTimeTranscriber,
+        RealTimeEvents,
+        RealTimeParameters,
+        RealTimeTranscriberOptions,
+        SpeechModel,
+    )
+
+    api_key = os.environ.get("ASSEMBLYAI_API_KEY")
+    if not api_key:
+        raise RuntimeError("Set ASSEMBLYAI_API_KEY before running this example")
+
+    application_name = args.application
+    if application_name is None:
+        application_name = input("Application to transcribe: ").strip()
+    if not application_name:
+        raise ValueError("Application name must not be empty")
+
+    session = pks_aio.Session(
+        sample_rate_hz=SAMPLE_RATE_HZ,
+        channels=1,
+        frame_duration_ms=20,
+    )
+    application = session.capture(pks.Source.application(application_name))
+    microphone = (
+        session.capture(pks.Source.microphone_default()) if args.microphone else None
+    )
+
+    channels_by_stem = {int(application.id): "application"}
+    if microphone is not None:
+        channels_by_stem[int(microphone.id)] = "microphone"
+
+    client = AsyncRealTimeTranscriber(RealTimeTranscriberOptions(api_key=api_key))
+    mixer = (
+        AsyncChannelStreamer(
+            client,
+            channels=["application", "microphone"],
+            sample_rate=SAMPLE_RATE_HZ,
+        )
+        if microphone is not None
+        else None
+    )
+
+    def on_turn(_client: object, event: object) -> None:
+        transcript = getattr(event, "transcript", "")
+        if not transcript:
+            return
+        channel = getattr(event, "channel", None) or "application"
+        print(f"[{channel}] {transcript}")
+
+    if mixer is None:
+        client.on(RealTimeEvents.Turn, on_turn)
+    else:
+        mixer.on(RealTimeEvents.Turn, on_turn)
+
+    async def start_transcription() -> None:
+        await client.connect(
+            RealTimeParameters(
+                sample_rate=SAMPLE_RATE_HZ,
+                speech_model=SpeechModel.universal_3_5_pro,
+                speaker_labels=True,
+            )
+        )
+
+    async def send_audio(frame: pks.AudioFrame) -> None:
+        channel = channels_by_stem.get(int(frame.stem_id))
+        if channel is None:
+            raise RuntimeError(
+                f"Received audio from undeclared stem {int(frame.stem_id)}"
+            )
+        samples = pcm_s16le(frame.samples)
+        if mixer is None:
+            await client.stream(samples)
+        else:
+            await mixer.stream(channel, samples)
+
+    async def stop_transcription() -> None:
+        if mixer is not None:
+            await mixer.flush()
+        await client.disconnect(terminate=True)
+
+    transcription = pks_aio.Connector(
+        start=start_transcription,
+        send=send_audio,
+        stop=stop_transcription,
+    )
+    application.send_to(transcription)
+    if microphone is not None:
+        microphone.send_to(transcription)
+
+    running = await session.start()
+
+    async def close_ended_channels() -> None:
+        if mixer is None:
+            return
+        closed: set[str] = set()
+        async for event in running.events:
+            if event.kind != SessionEventType.SOURCE_FAILURE or event.stem_id is None:
+                continue
+            channel = channels_by_stem.get(int(event.stem_id))
+            if channel is not None and channel not in closed:
+                await mixer.close_channel(channel)
+                closed.add(channel)
+
+    event_task = asyncio.create_task(close_ended_channels())
+    try:
+        if args.duration is None:
+            await asyncio.to_thread(input, "Press Enter to stop.\n")
+        else:
+            await asyncio.sleep(args.duration)
+    finally:
+        await running.stop()
+        await event_task
+
+
+def main() -> None:
+    try:
+        asyncio.run(run(parse_args()))
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_streaming_dual_channel_example.py
+++ b/tests/unit/test_streaming_dual_channel_example.py
@@ -1,0 +1,56 @@
+import importlib.util
+from array import array
+from pathlib import Path
+
+import pytest
+
+EXAMPLE_PATH = Path(__file__).parents[2] / "examples" / "streaming_dual_channel.py"
+
+
+def load_example():
+    spec = importlib.util.spec_from_file_location(
+        "streaming_dual_channel_example", EXAMPLE_PATH
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_default_capture_uses_application_only():
+    example = load_example()
+
+    args = example.parse_args([])
+
+    assert args.application is None
+    assert args.microphone is False
+    assert args.duration is None
+
+
+def test_capture_options_are_explicit():
+    example = load_example()
+
+    args = example.parse_args(
+        ["--application", "Zoom", "--microphone", "--duration", "5"]
+    )
+
+    assert args.application == "Zoom"
+    assert args.microphone is True
+    assert args.duration == 5
+
+
+def test_duration_must_be_positive():
+    example = load_example()
+
+    with pytest.raises(SystemExit):
+        example.parse_args(["--duration", "0"])
+
+
+def test_pcm_conversion_clips_and_uses_little_endian():
+    example = load_example()
+    samples = memoryview(array("f", [-2.0, -1.0, 0.0, 1.0, 2.0]))
+
+    result = example.pcm_s16le(samples)
+
+    assert result == b"\x00\x80\x00\x80\x00\x00\xff\x7f\xff\x7f"


### PR DESCRIPTION
## Summary

Adds the missing dual-channel streaming example referenced by the README.

The example uses PocketStation 0.1.3 to capture a selected desktop application and, when requested, the default microphone. Each source keeps its own AssemblyAI channel, and a source that ends closes only its channel so the other source can continue.

The microphone remains off unless `--microphone` is passed. Application capture does not require a virtual audio device.

## Run it

```bash
python -m pip install assemblyai==1.3.0 pocketstation==0.1.3
export ASSEMBLYAI_API_KEY=your_api_key
python examples/streaming_dual_channel.py
```

## Verification

- `ruff format --check --config ruff.toml examples/streaming_dual_channel.py tests/unit/test_streaming_dual_channel_example.py`
- `ruff check --config ruff.toml examples/streaming_dual_channel.py tests/unit/test_streaming_dual_channel_example.py`
- `mypy examples/streaming_dual_channel.py --follow-imports=silent --ignore-missing-imports`
- `pytest -q` — 485 passed
- Clean Python 3.12 environment installed `assemblyai==1.3.0` and `pocketstation==0.1.3` from PyPI; imports and example CLI passed

The AssemblyAI network session was not run because this environment does not have an `ASSEMBLYAI_API_KEY`. The PR does not claim a live-provider result.

This is an examples-and-documentation change, so the `skip-version-bump` label is appropriate.
