### PR TITLE
docs: drop README link to nonexistent dual-channel example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1141,8 +1141,6 @@ Back-filled words are flagged `word.channel_resolved = True`; confident per-word
 - Capturing the system/speaker output is platform-specific: macOS needs a loopback driver (e.g. BlackHole); Windows uses WASAPI loopback; Linux a PulseAudio/PipeWire monitor source.
 - If the mic physically picks up the speakers, that bleed can pull attribution toward `mic`. Apply acoustic echo cancellation at capture (`getUserMedia({ audio: { echoCancellation: true } })` in browser front-ends, or an AEC-capable native path) — the SDK only receives already-captured PCM, so it can't apply AEC itself. Transcription quality is unaffected; only the `channel` field.
 
-See [`examples/streaming_dual_channel.py`](./examples/streaming_dual_channel.py) for a complete runnable demo.
-
 </details>
 
 <details>


### PR DESCRIPTION
## Summary

The dual-channel streaming section of the README linked to `examples/streaming_dual_channel.py` "for a complete runnable demo", but no `examples/` directory exists in this repo. This removes the dangling reference.

Docs-only change, no code touched, so `skip-version-bump` applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
