### PR TITLE
feat(sync): make the live connection the only one the client opens

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,6 +430,12 @@ for word in result.words:
 
 The input can be a local file path, raw `bytes`, or a binary file object — but not a URL. Pass a path/bytes, or use `aai.Transcriber` for URL ingestion.
 
+Every entry point here opens the same connection: the audio is uploaded as a
+stream, and the service transcribes each speech segment as it lands. A clip
+you already have is simply a stream whose bytes are all ready at once, so
+`transcribe()` is the ergonomic shape rather than a different request. Audio
+must be WAV or raw PCM.
+
 </details>
 
 <details>

--- a/assemblyai/sync/v1/_base.py
+++ b/assemblyai/sync/v1/_base.py
@@ -212,7 +212,10 @@ class _SyncTranscriberImpl:
             audio_content_type=content_type,
             model=config.model,
             config=_config_to_json(config),
-            timeout=self._client.settings.sync_http_timeout,
+            # The live timeout: this rides the same streamed connection, whose
+            # per-operation shape bounds each socket write and read rather than
+            # the request end to end.
+            timeout=self._client.settings.sync_live_http_timeout,
         )
 
     def transcribe_live(

--- a/assemblyai/sync/v1/api.py
+++ b/assemblyai/sync/v1/api.py
@@ -1,5 +1,4 @@
-import json
-from typing import Dict, Iterator, Optional, Tuple
+from typing import Iterator, Optional
 
 import httpx
 
@@ -8,8 +7,14 @@ from ._multipart import AudioChunks, StreamingMultipartEncoder, iter_chunks
 
 # Canonical paths since the sync API gained a /v1 prefix (#18103); the
 # unprefixed routes remain served for SDK versions that predate it.
+#
+# `/v1/transcribe/live` is the one endpoint this client posts audio to. It is
+# also served at `/v1/transcribe/stream`, the path it shipped under, so an
+# older deployment still answers there — but `live` is its name.
+ENDPOINT_TRANSCRIBE_LIVE = "/v1/transcribe/live"
+# The buffered endpoint. Still served, and still exported through the legacy
+# `assemblyai.sync_api` shim, but nothing here requests it.
 ENDPOINT_TRANSCRIBE = "/v1/transcribe"
-ENDPOINT_TRANSCRIBE_STREAM = "/v1/transcribe/stream"
 ENDPOINT_WARM = "/v1/warm"
 MODEL_HEADER = "X-AAI-Model"
 
@@ -72,7 +77,13 @@ def transcribe(
     timeout: float,
 ) -> types.SyncTranscriptResponse:
     """
-    Posts a single synchronous transcription request.
+    Posts a transcription request for audio that is already complete.
+
+    Sends it over the same live connection `transcribe_live` uses, as a single
+    chunk: audio that already exists is a stream whose bytes are all ready at
+    once. There is one request shape in this client, so a complete clip and a
+    live capture reach the service the same way, and the server transcribes
+    each speech segment as it lands either way.
 
     Args:
         client: the HTTP client (carries the `Authorization` header).
@@ -81,36 +92,23 @@ def transcribe(
         filename: name for the audio multipart part.
         audio_content_type: `audio/wav` or `audio/pcm`; selects the decoder.
         model: sent as the `X-AAI-Model` routing header.
-        config: the JSON `config` part, or None to omit it.
-        timeout: per-request timeout in seconds.
+        config: the JSON `config` part, or None for an empty one.
+        timeout: per-operation timeout in seconds.
 
     Returns: the parsed transcript response.
 
     Raises: `SyncTranscriptError` on any non-200 response.
     """
-    files: Dict[str, Tuple[Optional[str], bytes, str]] = {
-        "audio": (filename, audio, audio_content_type)
-    }
-    if config:
-        # httpx <0.23 rejects a `str` multipart part; encode to bytes so the
-        # config part works across the full supported httpx range (>=0.19).
-        files["config"] = (
-            None,
-            json.dumps(config).encode("utf-8"),
-            "application/json",
-        )
-
-    response = client.post(
-        base_url.rstrip("/") + ENDPOINT_TRANSCRIBE,
-        files=files,
-        headers={MODEL_HEADER: model},
+    return transcribe_live(
+        client,
+        base_url=base_url,
+        chunks=(audio,),
+        filename=filename,
+        audio_content_type=audio_content_type,
+        model=model,
+        config=config,
         timeout=timeout,
     )
-
-    if response.status_code != httpx.codes.OK:
-        raise _error_from_response(response)
-
-    return types.SyncTranscriptResponse.parse_obj(response.json())
 
 
 def transcribe_live(
@@ -173,7 +171,7 @@ def transcribe_live(
         yield encoder.closing()
 
     response = client.post(
-        base_url.rstrip("/") + ENDPOINT_TRANSCRIBE_STREAM,
+        base_url.rstrip("/") + ENDPOINT_TRANSCRIBE_LIVE,
         content=body(),
         headers={MODEL_HEADER: model, "Content-Type": encoder.content_type},
         timeout=timeout,

--- a/assemblyai/sync/v1/async_api.py
+++ b/assemblyai/sync/v1/async_api.py
@@ -4,16 +4,14 @@ Calls the same endpoint as its sync twin and raises the same
 `SyncTranscriptError` through `api._error_from_response`.
 """
 
-import json
-from typing import AsyncIterator, Dict, Optional, Tuple
+from typing import AsyncIterator, Optional
 
 import httpx
 
 from ... import types
 from ._multipart import AsyncAudioChunks, StreamingMultipartEncoder, aiter_chunks
 from .api import (
-    ENDPOINT_TRANSCRIBE,
-    ENDPOINT_TRANSCRIBE_STREAM,
+    ENDPOINT_TRANSCRIBE_LIVE,
     MODEL_HEADER,
     _error_from_response,
 )
@@ -33,45 +31,21 @@ async def transcribe(
     timeout: float,
 ) -> types.SyncTranscriptResponse:
     """
-    Posts a single synchronous transcription request.
+    Posts a transcription request for audio that is already complete.
 
-    Args:
-        client: the HTTP client (carries the `Authorization` header).
-        base_url: the sync API base URL, e.g. `https://sync.assemblyai.com`.
-        audio: raw audio bytes (WAV container or S16LE PCM).
-        filename: name for the audio multipart part.
-        audio_content_type: `audio/wav` or `audio/pcm`; selects the decoder.
-        model: sent as the `X-AAI-Model` routing header.
-        config: the JSON `config` part, or None to omit it.
-        timeout: per-request timeout in seconds.
-
-    Returns: the parsed transcript response.
-
-    Raises: `SyncTranscriptError` on any non-200 response.
+    The asyncio counterpart of `api.transcribe`: the same single-chunk send
+    over the live connection, which is the only one this client opens.
     """
-    files: Dict[str, Tuple[Optional[str], bytes, str]] = {
-        "audio": (filename, audio, audio_content_type)
-    }
-    if config:
-        # httpx <0.23 rejects a `str` multipart part; encode to bytes so the
-        # config part works across the full supported httpx range (>=0.19).
-        files["config"] = (
-            None,
-            json.dumps(config).encode("utf-8"),
-            "application/json",
-        )
-
-    response = await client.post(
-        base_url.rstrip("/") + ENDPOINT_TRANSCRIBE,
-        files=files,
-        headers={MODEL_HEADER: model},
+    return await transcribe_live(
+        client,
+        base_url=base_url,
+        chunks=(audio,),
+        filename=filename,
+        audio_content_type=audio_content_type,
+        model=model,
+        config=config,
         timeout=timeout,
     )
-
-    if response.status_code != httpx.codes.OK:
-        raise _error_from_response(response)
-
-    return types.SyncTranscriptResponse.parse_obj(response.json())
 
 
 async def transcribe_live(
@@ -123,7 +97,7 @@ async def transcribe_live(
         yield encoder.closing()
 
     response = await client.post(
-        base_url.rstrip("/") + ENDPOINT_TRANSCRIBE_STREAM,
+        base_url.rstrip("/") + ENDPOINT_TRANSCRIBE_LIVE,
         content=body(),
         headers={MODEL_HEADER: model, "Content-Type": encoder.content_type},
         timeout=timeout,

--- a/assemblyai/sync/v1/async_client.py
+++ b/assemblyai/sync/v1/async_client.py
@@ -296,7 +296,8 @@ class AsyncSyncTranscriber:
             audio_content_type=content_type,
             model=config.model,
             config=_config_to_json(config),
-            timeout=self._client.settings.sync_http_timeout,
+            # The live timeout: this rides the same streamed connection.
+            timeout=self._client.settings.sync_live_http_timeout,
         )
 
     async def transcribe_live(

--- a/tests/unit/test_dx.py
+++ b/tests/unit/test_dx.py
@@ -29,7 +29,7 @@ aai.settings.api_key = "test"
 
 TRANSCRIPT_URL = f"{aai.settings.base_url}{ENDPOINT_TRANSCRIPT}"
 UPLOAD_URL = f"{aai.settings.base_url}{ENDPOINT_UPLOAD}"
-SYNC_TRANSCRIBE_URL = f"{aai.settings.sync_base_url}/v1/transcribe"
+SYNC_TRANSCRIBE_URL = f"{aai.settings.sync_base_url}/v1/transcribe/live"
 
 _SYNC_OK_RESPONSE = {
     "text": "hello world",

--- a/tests/unit/test_sync.py
+++ b/tests/unit/test_sync.py
@@ -6,7 +6,7 @@ import assemblyai as aai
 
 aai.settings.api_key = "test"
 
-TRANSCRIBE_URL = f"{aai.settings.sync_base_url}/v1/transcribe"
+TRANSCRIBE_URL = f"{aai.settings.sync_base_url}/v1/transcribe/live"
 WARM_URL = f"{aai.settings.sync_base_url}/v1/warm"
 
 _OK_RESPONSE = {
@@ -78,8 +78,10 @@ def test_transcribe_sends_model_header_and_wav_part(httpx_mock: HTTPXMock):
     body = request.read()
     assert b'name="audio"' in body
     assert b"Content-Type: audio/wav" in body
-    # And no config part is sent when the config is empty
-    assert b'name="config"' not in body
+    # And an empty config part still goes out, ahead of the audio: the endpoint
+    # decodes the audio as it arrives and will not start without one.
+    assert body.index(b'name="config"') < body.index(b'name="audio"')
+    assert b'Content-Type: application/json\r\n\r\n{}\r\n' in body
 
 
 def test_transcribe_sends_prompt_and_keyterms_prompt(httpx_mock: HTTPXMock):
@@ -210,11 +212,12 @@ def test_default_config_omits_language_code(httpx_mock: HTTPXMock):
     # Given a default config (no language specified)
     _mock_ok(httpx_mock)
 
-    # When transcribing, Then no config part is sent and the server defaults
-    # the language to English
+    # When transcribing, Then the config part carries no language and the
+    # server defaults it to English
     aai.SyncTranscriber().transcribe(b"RIFFfake-wav-bytes")
     body = httpx_mock.get_requests()[0].read()
-    assert b'name="config"' not in body
+    assert b'Content-Type: application/json\r\n\r\n{}\r\n' in body
+    assert b"language_code" not in body
 
 
 def test_transcribe_sends_timestamps_flag(httpx_mock: HTTPXMock):

--- a/tests/unit/test_sync_async.py
+++ b/tests/unit/test_sync_async.py
@@ -26,18 +26,44 @@ _OK_RESPONSE = {
 }
 
 
-async def _read_and_respond(request: httpx.Request) -> httpx.Response:
-    # Consume the streamed request body while the request is live. That caches
-    # it on the recorded request, so the `.read()` assertions below work on
-    # every supported httpx: the buffered path now streams its body, and older
-    # httpx/pytest_httpx do not consume a chunked request body on their own —
-    # a bare `.read()` then asserts on the unconsumed async stream.
-    await request.aread()
-    return httpx.Response(status_code=httpx.codes.OK, json=_OK_RESPONSE)
-
-
 def _mock_ok(httpx_mock: HTTPXMock) -> None:
-    httpx_mock.add_callback(_read_and_respond, url=TRANSCRIBE_URL, method="POST")
+    httpx_mock.add_response(
+        url=TRANSCRIBE_URL,
+        method="POST",
+        status_code=httpx.codes.OK,
+        json=_OK_RESPONSE,
+    )
+
+
+class _Captured(list):
+    """Bodies recorded as the requests were sent, in order."""
+
+    @property
+    def first(self) -> bytes:
+        return self[0]
+
+
+def _capture(transcriber, *, status: int = httpx.codes.OK) -> _Captured:
+    """Records each request body while the request is still open.
+
+    The buffered entry points stream their body like every other call, and a
+    streamed body can only be read once — `pytest_httpx` records the request
+    without reading it on older httpx, so a read after the call sees a spent
+    iterator. Reading inside the transport is the same approach
+    `test_sync_live.py` takes for its body-shape assertions.
+    """
+    captured = _Captured()
+
+    async def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(await request.aread())
+        captured.headers = request.headers
+        return httpx.Response(status, json=_OK_RESPONSE)
+
+    transcriber.client._http_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(handler),
+        headers=transcriber.client.http_client.headers,
+    )
+    return captured
 
 
 async def test_transcribe_bytes_parses_response(httpx_mock: HTTPXMock):
@@ -58,40 +84,37 @@ async def test_transcribe_bytes_parses_response(httpx_mock: HTTPXMock):
     assert result.request_time_ms == 243.7
 
 
-async def test_transcribe_sends_model_header_and_wav_part(httpx_mock: HTTPXMock):
-    # Given a mocked sync endpoint
-    _mock_ok(httpx_mock)
-
-    # When transcribing bytes with the default config
+async def test_transcribe_sends_model_header_and_wav_part():
+    # Given a transcriber whose transport records the body as it is sent
     async with aai.AsyncSyncTranscriber() as transcriber:
+        captured = _capture(transcriber)
+
+        # When transcribing bytes with the default config
         await transcriber.transcribe(b"RIFFfake-wav-bytes")
 
     # Then the request routes via X-AAI-Model and ships a WAV audio part
-    request = httpx_mock.get_requests()[0]
-    assert request.headers["X-AAI-Model"] == "universal-3-5-pro"
-    body = request.read()
+    assert captured.headers["X-AAI-Model"] == "universal-3-5-pro"
+    body = captured.first
     assert b'name="audio"' in body
     assert b"Content-Type: audio/wav" in body
     # And an empty config part still goes out, ahead of the audio: the endpoint
     # decodes the audio as it arrives and will not start without one.
     assert body.index(b'name="config"') < body.index(b'name="audio"')
-    assert b'Content-Type: application/json\r\n\r\n{}\r\n' in body
+    assert b"Content-Type: application/json\r\n\r\n{}\r\n" in body
 
 
-async def test_transcribe_sends_config_part(httpx_mock: HTTPXMock):
-    # Given a mocked sync endpoint
-    _mock_ok(httpx_mock)
-
+async def test_transcribe_sends_config_part():
     # When transcribing with a prompt and keyterms_prompt
     config = aai.SyncTranscriptionConfig(
         prompt="Transcribe verbatim.",
         keyterms_prompt=["AssemblyAI"],
     )
     async with aai.AsyncSyncTranscriber() as transcriber:
+        captured = _capture(transcriber)
         await transcriber.transcribe(b"RIFFfake-wav-bytes", config=config)
 
     # Then a config JSON part carries the options
-    body = httpx_mock.get_requests()[0].read()
+    body = captured.first
     assert b'name="config"' in body
     assert b"Transcribe verbatim." in body
     assert b'"AssemblyAI"' in body
@@ -99,15 +122,12 @@ async def test_transcribe_sends_config_part(httpx_mock: HTTPXMock):
     assert b'"model"' not in body
 
 
-async def test_transcribe_uses_default_config_and_per_call_override(
-    httpx_mock: HTTPXMock,
-):
+async def test_transcribe_uses_default_config_and_per_call_override():
     # Given a transcriber with a default config
-    _mock_ok(httpx_mock)
-    _mock_ok(httpx_mock)
     default = aai.SyncTranscriptionConfig(prompt="default prompt")
 
     async with aai.AsyncSyncTranscriber(config=default) as transcriber:
+        captured = _capture(transcriber)
         # When transcribing without a per-call config
         await transcriber.transcribe(b"RIFFfake-wav-bytes")
         # And with a per-call override
@@ -115,22 +135,20 @@ async def test_transcribe_uses_default_config_and_per_call_override(
         await transcriber.transcribe(b"RIFFfake-wav-bytes", config=override)
 
     # Then the default applies to the first call and the override to the second
-    first, second = (request.read() for request in httpx_mock.get_requests())
+    first, second = captured
     assert b"default prompt" in first
     assert b"override prompt" in second
 
 
-async def test_transcribe_pcm_sends_pcm_part_and_rate(httpx_mock: HTTPXMock):
-    # Given a mocked sync endpoint
-    _mock_ok(httpx_mock)
-
+async def test_transcribe_pcm_sends_pcm_part_and_rate():
     # When transcribing bytes with sample_rate + channels (raw PCM)
     config = aai.SyncTranscriptionConfig(sample_rate=16000, channels=1)
     async with aai.AsyncSyncTranscriber() as transcriber:
+        captured = _capture(transcriber)
         await transcriber.transcribe(b"\x00\x01" * 100, config=config)
 
     # Then the audio part is PCM and the config carries rate + channels
-    body = httpx_mock.get_requests()[0].read()
+    body = captured.first
     assert b"Content-Type: audio/pcm" in body
     assert b'"sample_rate"' in body
     assert b'"channels"' in body
@@ -154,20 +172,19 @@ async def test_transcribe_rejects_url():
             await transcriber.transcribe("https://example.com/audio.wav")
 
 
-async def test_transcribe_path_input(httpx_mock: HTTPXMock, tmp_path):
+async def test_transcribe_path_input(tmp_path):
     # Given a local WAV file
-    _mock_ok(httpx_mock)
     audio_file = tmp_path / "call.wav"
     audio_file.write_bytes(b"RIFFfake-wav-bytes")
 
     # When transcribing the path
     async with aai.AsyncSyncTranscriber() as transcriber:
+        captured = _capture(transcriber)
         result = await transcriber.transcribe(str(audio_file))
 
     # Then it succeeds and ships the file under its own name
     assert result.text == "hello world"
-    body = httpx_mock.get_requests()[0].read()
-    assert b'filename="call.wav"' in body
+    assert b'filename="call.wav"' in captured.first
 
 
 async def test_transcribe_gather_runs_concurrently(httpx_mock: HTTPXMock):

--- a/tests/unit/test_sync_async.py
+++ b/tests/unit/test_sync_async.py
@@ -10,7 +10,7 @@ pytestmark = pytest.mark.asyncio
 
 aai.settings.api_key = "test"
 
-TRANSCRIBE_URL = f"{aai.settings.sync_base_url}/v1/transcribe"
+TRANSCRIBE_URL = f"{aai.settings.sync_base_url}/v1/transcribe/live"
 WARM_URL = f"{aai.settings.sync_base_url}/v1/warm"
 
 _OK_RESPONSE = {
@@ -67,8 +67,10 @@ async def test_transcribe_sends_model_header_and_wav_part(httpx_mock: HTTPXMock)
     body = request.read()
     assert b'name="audio"' in body
     assert b"Content-Type: audio/wav" in body
-    # And no config part is sent when the config is empty
-    assert b'name="config"' not in body
+    # And an empty config part still goes out, ahead of the audio: the endpoint
+    # decodes the audio as it arrives and will not start without one.
+    assert body.index(b'name="config"') < body.index(b'name="audio"')
+    assert b'Content-Type: application/json\r\n\r\n{}\r\n' in body
 
 
 async def test_transcribe_sends_config_part(httpx_mock: HTTPXMock):

--- a/tests/unit/test_sync_async.py
+++ b/tests/unit/test_sync_async.py
@@ -26,13 +26,18 @@ _OK_RESPONSE = {
 }
 
 
+async def _read_and_respond(request: httpx.Request) -> httpx.Response:
+    # Consume the streamed request body while the request is live. That caches
+    # it on the recorded request, so the `.read()` assertions below work on
+    # every supported httpx: the buffered path now streams its body, and older
+    # httpx/pytest_httpx do not consume a chunked request body on their own —
+    # a bare `.read()` then asserts on the unconsumed async stream.
+    await request.aread()
+    return httpx.Response(status_code=httpx.codes.OK, json=_OK_RESPONSE)
+
+
 def _mock_ok(httpx_mock: HTTPXMock) -> None:
-    httpx_mock.add_response(
-        url=TRANSCRIBE_URL,
-        method="POST",
-        status_code=httpx.codes.OK,
-        json=_OK_RESPONSE,
-    )
+    httpx_mock.add_callback(_read_and_respond, url=TRANSCRIBE_URL, method="POST")
 
 
 async def test_transcribe_bytes_parses_response(httpx_mock: HTTPXMock):

--- a/tests/unit/test_sync_live.py
+++ b/tests/unit/test_sync_live.py
@@ -873,7 +873,11 @@ def test_the_buffered_endpoint_is_never_requested(httpx_mock: HTTPXMock):
     and the service still serves it — but nothing here sends to it, so a
     mocked buffered endpoint goes unused whichever way audio is submitted.
     """
-    httpx_mock.add_response(url=STREAM_URL, json=_OK_RESPONSE, is_reusable=True)
+    # One response per submission below. `is_reusable` is only on newer
+    # pytest_httpx, and the floor envs pin the release that shipped with their
+    # httpx, so queue a response for each call instead.
+    for _ in range(4):
+        httpx_mock.add_response(url=STREAM_URL, json=_OK_RESPONSE)
 
     transcriber = aai.SyncTranscriber()
     transcriber.transcribe(b"RIFFfake-wav-bytes")

--- a/tests/unit/test_sync_live.py
+++ b/tests/unit/test_sync_live.py
@@ -22,7 +22,7 @@ from assemblyai.sync.v1._multipart import _STREAM_READ_SIZE
 
 aai.settings.api_key = "test"
 
-STREAM_URL = f"{aai.settings.sync_base_url}/v1/transcribe/stream"
+STREAM_URL = f"{aai.settings.sync_base_url}/v1/transcribe/live"
 
 _OK_RESPONSE = {
     "text": "hello world",
@@ -830,3 +830,58 @@ def test_async_open_live_needs_a_running_loop():
     # When a session is opened, then the mistake is named rather than deferred
     with pytest.raises(RuntimeError, match="no running event loop"):
         transcriber.open_live()
+
+
+def test_complete_audio_goes_over_the_live_connection(httpx_mock: HTTPXMock):
+    """`transcribe()` opens the same connection `transcribe_live()` does.
+
+    There is one request shape in this client: a complete clip is a stream
+    whose bytes happen to all be ready, so it takes the streamed endpoint and
+    the chunked framing rather than a second, buffered path.
+    """
+    httpx_mock.add_response(url=STREAM_URL, json=_OK_RESPONSE)
+
+    aai.SyncTranscriber().transcribe(b"RIFFfake-wav-bytes")
+
+    request = httpx_mock.get_requests()[0]
+    assert str(request.url) == STREAM_URL
+    # Chunked, not a declared length: the encoder frames an unsized iterator.
+    assert "content-length" not in request.headers
+    body = request.read()
+    assert body.index(b'name="config"') < body.index(b'name="audio"')
+    assert b"RIFFfake-wav-bytes" in body
+
+
+@pytest.mark.asyncio
+async def test_async_complete_audio_goes_over_the_live_connection(
+    httpx_mock: HTTPXMock,
+):
+    httpx_mock.add_response(url=STREAM_URL, json=_OK_RESPONSE)
+
+    async with aai.AsyncSyncTranscriber() as transcriber:
+        await transcriber.transcribe(b"RIFFfake-wav-bytes")
+
+    request = httpx_mock.get_requests()[0]
+    assert str(request.url) == STREAM_URL
+    assert "content-length" not in request.headers
+
+
+def test_the_buffered_endpoint_is_never_requested(httpx_mock: HTTPXMock):
+    """No entry point on this client posts to `/v1/transcribe`.
+
+    The path is still exported for the legacy `assemblyai.sync_api` surface,
+    and the service still serves it — but nothing here sends to it, so a
+    mocked buffered endpoint goes unused whichever way audio is submitted.
+    """
+    httpx_mock.add_response(url=STREAM_URL, json=_OK_RESPONSE, is_reusable=True)
+
+    transcriber = aai.SyncTranscriber()
+    transcriber.transcribe(b"RIFFfake-wav-bytes")
+    transcriber.transcribe_async(b"RIFFfake-wav-bytes").result()
+    transcriber.transcribe_live([b"RIFFfake", b"-wav-bytes"])
+    with transcriber.open_live(aai.SyncTranscriptionConfig()) as session:
+        session.write(b"RIFFfake-wav-bytes")
+    session.result()
+
+    requested = {str(request.url) for request in httpx_mock.get_requests()}
+    assert requested == {STREAM_URL}

--- a/tests/unit/test_sync_live.py
+++ b/tests/unit/test_sync_live.py
@@ -873,9 +873,8 @@ def test_the_buffered_endpoint_is_never_requested(httpx_mock: HTTPXMock):
     and the service still serves it — but nothing here sends to it, so a
     mocked buffered endpoint goes unused whichever way audio is submitted.
     """
-    # One response per submission below. `is_reusable` is only on newer
-    # pytest_httpx, and the floor envs pin the release that shipped with their
-    # httpx, so queue a response for each call instead.
+    # One registration per call rather than a reusable one: the `is_reusable`
+    # kwarg postdates the oldest pytest-httpx the matrix tests against.
     for _ in range(4):
         httpx_mock.add_response(url=STREAM_URL, json=_OK_RESPONSE)
 


### PR DESCRIPTION
Stacked on #244 (`ccampbell/sync-live-session`), which is itself stacked on #241. This PR adds only the consolidation on top.

## What

Every entry point — `transcribe()`, `transcribe_async()`, `transcribe_live()`, `open_live()` — now posts to `/v1/transcribe/live`. There is one connection in this client.

Audio that is already complete is a stream whose bytes happen to all be ready, so it goes out over that connection as a single chunk rather than through a separate buffered request. What that buys is one request shape to reason about: one framing, one set of errors, one timeout — and a complete clip reaches the service exactly the way a live capture does, with each speech segment transcribed as it lands instead of after the upload finishes.

The endpoint constant becomes `ENDPOINT_TRANSCRIBE_LIVE = "/v1/transcribe/live"`, following the rename in [DeepLearning #20044](https://github.com/AssemblyAI/DeepLearning/pull/20044) (merged and live in production).

## The public surface is unchanged

`api.transcribe()` keeps its exact signature and delegates to `transcribe_live()`, so the legacy `assemblyai.sync_api` shim still re-exports it and `test_old_sync_api_module_surface_is_preserved` still passes. `ENDPOINT_TRANSCRIBE` stays exported for the same reason, with a comment noting nothing here requests it.

I went this way deliberately rather than deleting the buffered function: that test pins the old flat module's surface as a compatibility contract, and breaking it would be a major-version change for no gain — the goal is one *connection*, not a smaller import surface.

Note this is a client-side consolidation only. Sync still serves both `/v1/transcribe` and `/v1/transcribe/live`, and both stay.

## One observable change

An empty config used to mean **no `config` part at all**. The live endpoint requires one ahead of the audio, so `{}` now goes out instead. Anyone inspecting the wire will always see a config part. Two tests asserting the old absence are updated to assert the presence and the ordering.

Complete-audio calls also move from `sync_http_timeout` to `sync_live_http_timeout`, whose per-operation shape is the right one for a streamed body. `sync_http_timeout` still backs the warm-up.

Compressed formats are not a concern here: this client has always been WAV/PCM only (`_resolve_audio` picks between `audio/wav` and `audio/pcm`), which is exactly what the live endpoint accepts.

## Validation

- **531 unit tests pass** (528 before, 3 new), re-run against the current base after each rebase. Verified the baseline first: the base branch is 528/528 on the same interpreter, so every failure I saw along the way was mine to fix.
- New tests pin the invariant: `transcribe()` and its async twin hit the live URL with no `Content-Length` and config-before-audio, and one test drives all four entry points and asserts the set of requested URLs is exactly `{/v1/transcribe/live}` — so a buffered request reappearing anywhere fails.
- `ruff check` and `ruff format --check` clean on `assemblyai/`; `mypy` reports **zero** errors in `sync/v1` (the errors elsewhere are pre-existing and identical to the base).

## No version bump

The stack lands on master as one merge, so the version is set once at the top rather than per PR — this branch leaves `__version__` alone. The test matrix and version-bump workflows only trigger for PRs into master, so only lint runs here until the base moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)