### PR TITLE
docs: replace inaccessible example.com/example.org audio URLs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@ import assemblyai as aai
 aai.settings.api_key = os.environ["ASSEMBLYAI_API_KEY"]
 
 transcript = aai.Transcriber().transcribe(
-    "https://example.com/audio.mp3",
+    "https://assembly.ai/wildfires.mp3",
     config=aai.TranscriptionConfig(
         speech_models=["universal-3-5-pro", "universal-2"],
         speaker_labels=True,

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -32,7 +32,7 @@ from assemblyai import TranscriptStatus
 from assemblyai.prerecorded.v2 import Transcriber
 
 transcript = Transcriber(api_key="YOUR_API_KEY").transcribe(
-    "https://example.org/audio.wav"
+    "https://assembly.ai/wildfires.mp3"
 )
 
 if transcript.status == TranscriptStatus.error:
@@ -143,7 +143,7 @@ from assemblyai.prerecorded.v2 import AsyncTranscriber
 
 async def main():
     async with AsyncTranscriber(api_key="YOUR_API_KEY") as transcriber:
-        transcript = await transcriber.transcribe("https://example.org/audio.wav")
+        transcript = await transcriber.transcribe("https://assembly.ai/wildfires.mp3")
         print(transcript.text)
 
 
@@ -164,7 +164,7 @@ transcriber = Transcriber(api_key="YOUR_API_KEY")
 
 try:
     transcript = transcriber.transcribe(
-        "https://example.org/audio.wav",
+        "https://assembly.ai/wildfires.mp3",
         poll_timeout=300,
     )
 except TranscriptError as error:
@@ -183,7 +183,7 @@ from assemblyai import TranscriptStatus
 from assemblyai.prerecorded.v2 import Transcriber
 
 transcriber = Transcriber(api_key="YOUR_API_KEY")
-transcript = transcriber.transcribe("https://example.org/audio.wav")
+transcript = transcriber.transcribe("https://assembly.ai/wildfires.mp3")
 
 if transcript.status == TranscriptStatus.error:
     raise RuntimeError(f"Transcription failed: {transcript.error}")

--- a/README.md
+++ b/README.md
@@ -975,7 +975,7 @@ aai.settings.api_key = "<YOUR_API_KEY>"
 async def main():
     async with aai.AsyncTranscriber() as transcriber:
         # Returns as soon as the job is queued - no polling.
-        transcript = await transcriber.submit("https://example.org/audio.mp3")
+        transcript = await transcriber.submit("https://assembly.ai/wildfires.mp3")
         print(transcript.id, transcript.status)
 
         # Later, in the same or another process:
@@ -1629,7 +1629,7 @@ config = aai.TranscriptionConfig(punctuate=False, format_text=False)
 transcriber = aai.Transcriber(config=config)
 
 # will use the same config for all `.transcribe*(...)` operations
-transcriber.transcribe("https://example.org/audio.wav")
+transcriber.transcribe("https://assembly.ai/wildfires.mp3")
 ```
 
 ### Overriding Defaults
@@ -1651,7 +1651,7 @@ config = aai.TranscriptionConfig(punctuate=False, format_text=False)
 transcriber = aai.Transcriber(config=config)
 
 transcriber.transcribe(
-    "https://example.com/audio.mp3",
+    "https://assembly.ai/wildfires.mp3",
     # overrides the above configuration on the `Transcriber` with the following
     config=aai.TranscriptionConfig(speech_models=["universal-3-5-pro", "universal-2"], multichannel=True, disfluencies=True)
 )


### PR DESCRIPTION
## Summary

- `README.md`, `MIGRATION.md`, and `CLAUDE.md` used `https://example.com/...` and `https://example.org/...` as the `audio_url` in several runnable code snippets. Neither domain hosts a real audio file, so copying these examples verbatim and running them fails.
- Replaced all 8 occurrences with the SDK's existing working sample, `https://assembly.ai/wildfires.mp3`, which is already used elsewhere in `README.md`.
- Left the `example.org`/`example` URLs in `tests/unit/*.py` unchanged — those are mocked HTTP fixture values (via `pytest_httpx`) that never make a real network request, so they aren't "inaccessible" in the same sense.

## Test plan

- [ ] Docs-only change; no functional code touched. Visually confirmed the diff replaces only placeholder URLs in prose/code-block examples.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01666CNFKsEvUhKVrpGScNLo

---
_Generated by [Claude Code](https://claude.ai/code/session_01666CNFKsEvUhKVrpGScNLo)_